### PR TITLE
Add compatibility for 1.15-Snapshot (19w38a-)

### DIFF
--- a/src/main/java/dynamicfps/DynamicFPSMod.java
+++ b/src/main/java/dynamicfps/DynamicFPSMod.java
@@ -22,7 +22,7 @@ public class DynamicFPSMod implements ModInitializer {
 	 */
 	public static boolean checkForRender() {
 		MinecraftClient client = MinecraftClient.getInstance();
-		Window window = client.window;
+		Window window = ((WindowHolder) client).getWindow();
 		
 		long currentTime = SystemUtil.getMeasuringTimeMs();
 		
@@ -37,5 +37,12 @@ public class DynamicFPSMod implements ModInitializer {
 			LockSupport.parkNanos("waiting to render", 30_000_000); // 30 ms
 		}
 		return shouldRender;
+	}
+	
+	/**
+	 Compatibility interface to support both 1.14.x and 1.15.x
+	*/
+	public interface WindowHolder {
+		Window getWindow();
 	}
 }

--- a/src/main/java/dynamicfps/mixin/MinecraftClientMixin.java
+++ b/src/main/java/dynamicfps/mixin/MinecraftClientMixin.java
@@ -1,0 +1,20 @@
+package dynamicfps.mixin;
+
+import dynamicfps.DynamicFPSMod.WindowHolder;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.util.Window;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+@Mixin(MinecraftClient.class)
+public class MinecraftClientMixin implements WindowHolder {
+	@Shadow
+	@Final
+	private Window window;
+	
+	@Override
+	public Window getWindow() {
+		return window;
+	}
+}

--- a/src/main/resources/dynamicfps.mixins.json
+++ b/src/main/resources/dynamicfps.mixins.json
@@ -6,6 +6,7 @@
   ],
   "client": [
     "GameRendererMixin",
+    "MinecraftClientMixin",
     "ThreadExecutorMixin"
   ],
   "injectors": {


### PR DESCRIPTION
This PR adds compatibility for `1.15-Snapshot` (`19w38a`-).
This code supports both `1.14.4` and the current snapshot (and hopefully later ones).
I'm sorry if you don't want to support unstable snapshot versions, but I would be happy if you consider accepting this patch :)
