### PR TITLE
Fix resource reload screen fadeout animation

### DIFF
--- a/src/main/java/dynamicfps/DynamicFPSMod.java
+++ b/src/main/java/dynamicfps/DynamicFPSMod.java
@@ -139,4 +139,8 @@ public class DynamicFPSMod implements ModInitializer {
 	public interface WindowHolder {
 		Window getWindow();
 	}
+	
+	public interface SplashCompletedHolder {
+		boolean isReloadComplete();
+	}
 }

--- a/src/main/java/dynamicfps/mixin/GameRendererMixin.java
+++ b/src/main/java/dynamicfps/mixin/GameRendererMixin.java
@@ -1,6 +1,7 @@
 package dynamicfps.mixin;
 
 import dynamicfps.DynamicFPSMod;
+import dynamicfps.DynamicFPSMod.SplashCompletedHolder;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.SplashScreen;
 import net.minecraft.client.render.GameRenderer;
@@ -31,7 +32,9 @@ public class GameRendererMixin {
 	@Inject(at = @At("HEAD"), method = "renderWorld", cancellable = true)
 	private void onRenderWorld(CallbackInfo callbackInfo) {
 		if (client.getOverlay() instanceof SplashScreen) {
-			callbackInfo.cancel();
+			if (!((SplashCompletedHolder)client.getOverlay()).isReloadComplete()) {
+				callbackInfo.cancel();
+			}
 		}
 	}
 }

--- a/src/main/java/dynamicfps/mixin/SplashScreenMixin.java
+++ b/src/main/java/dynamicfps/mixin/SplashScreenMixin.java
@@ -1,0 +1,16 @@
+package dynamicfps.mixin;
+
+import dynamicfps.DynamicFPSMod.SplashCompletedHolder;
+import net.minecraft.client.gui.screen.SplashScreen;
+import org.spongepowered.asm.mixin.*;
+
+@Mixin(SplashScreen.class)
+public class SplashScreenMixin implements SplashCompletedHolder {
+	@Shadow
+	private long reloadCompleteTime;
+
+	@Override
+	public boolean isReloadComplete() {
+		return reloadCompleteTime > -1L;
+	}
+}

--- a/src/main/resources/dynamicfps.mixins.json
+++ b/src/main/resources/dynamicfps.mixins.json
@@ -7,6 +7,7 @@
   "client": [
     "GameRendererMixin",
     "MinecraftClientMixin",
+    "SplashScreenMixin",
     "ThreadExecutorMixin"
   ],
   "injectors": {


### PR DESCRIPTION
Fixes #31.

This PR fixes the resource reloading screen fadeout animation by adding a mixin to access whether the reload is complete (and therefore it's fading out) and not cancelling if that's the case. The check is the same one that vanilla uses to fade out.

The screen can actually be shown often when you play servers with custom resource packs, even more if those are per-world/per-game, since they can get reloaded every few minutes in some cases.