### PR TITLE
Implement FREX Frawless Frames API

### DIFF
--- a/src/main/java/dynamicfps/DynamicFPSMod.java
+++ b/src/main/java/dynamicfps/DynamicFPSMod.java
@@ -44,6 +44,7 @@ public class DynamicFPSMod implements ModInitializer {
 		toggleDisabledKeyBinding.register();
 		
 		HudRenderCallback.EVENT.register(new HudInfoRenderer());
+		FlawlessFrames.onClientInitialization();
 	}
 	
 	private static long lastRender;
@@ -53,7 +54,7 @@ public class DynamicFPSMod implements ModInitializer {
 	 @return whether or not the game should be rendered after this.
 	 */
 	public static boolean checkForRender() {
-		if (isDisabled) return true;
+		if (isDisabled || FlawlessFrames.isActive()) return true;
 		
 		checkForGC();
 		

--- a/src/main/java/dynamicfps/FlawlessFrames.java
+++ b/src/main/java/dynamicfps/FlawlessFrames.java
@@ -1,0 +1,43 @@
+package dynamicfps;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import net.fabricmc.loader.api.FabricLoader;
+
+/**
+ * Implements the FREX Flawless Frames API to allow other mods to request all frames to be processed until requested to
+ * go back to normal operation, such as ReplayMod rendering a video.<p>
+ * 
+ * See https://github.com/grondag/frex/pull/9
+ *
+ */
+public class FlawlessFrames {
+	private static final Set<Object> ACTIVE = ConcurrentHashMap.newKeySet();
+	
+	@SuppressWarnings("unchecked") // Since we ask for Consumer.class, it's unchecked to pass a Consumer<Boolean> to it. But it's guaranteed to ask it by API
+	static void onClientInitialization() {
+		Function<String, Consumer<Boolean>> provider = name -> {
+			Object token = new Object();
+			return active -> {
+				if (active) {
+					ACTIVE.add(token);
+				} else {
+					ACTIVE.remove(token);
+				}
+			};
+		};
+		FabricLoader.getInstance()
+			.getEntrypoints("frex_flawless_frames", Consumer.class)
+			.forEach(api -> api.accept(provider));
+	}
+	
+	/**
+	 * Returns whether one or more mods have requested Flawless Frames to be active, and therefore frames should not be skipped.
+	 */
+	public static boolean isActive() {
+		return !ACTIVE.isEmpty();
+	}
+}


### PR DESCRIPTION
Should fix #40.

Implements the FREX Flawless Frames API (grondag/frex#9) in order to allow other mods to request all frames to be processed until requested to go back to normal operation, such as ReplayMod rendering a video.

The implementation is based on the one from CaffeineMC/sodium-fabric#791 (that is very similar to the one from base FREX, other than ignoring the id of the mod requesting the change, since that's only for debugging).

There's basically a Concurrent Set that stores the token of the mods that have requested Flawless Frames to be active (if any). The tokens are created once per mod (in the `Function`) and stored in their `Consumer` lambdas so they are always the same ones and can be properly removed from the set.

Note that I haven't tested this (other than it launches, since I don't really know what to look for or in what cases), but it seems correct to me, and is based in an implementation that should work.

Should work the same way in 1.16 if you want to backport it.