### PR TITLE
Fix setting sound volume to 0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'fabric-loom' version '0.10-SNAPSHOT'
 	id 'maven-publish'
-	id 'org.quiltmc.quilt-mappings-on-loom' version '3.1.1'
+	id 'org.quiltmc.quilt-mappings-on-loom' version '3.1.2'
 }
 
 sourceCompatibility = JavaVersion.VERSION_17

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,10 +3,10 @@ org.gradle.jvmargs = -Xmx1G
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop/
-minecraft_version = 1.18.1
-quilt_mappings = 5
-loader_version = 0.12.12
-fabric_version = 0.46.0+1.18
+minecraft_version = 1.18.2
+quilt_mappings = 23
+loader_version = 0.14.5
+fabric_version = 0.51.1+1.18.2
 
 # Mod Properties
 mod_version = 2.1.0
@@ -16,6 +16,6 @@ archives_base_name = dynamic-fps
 # Dependencies
 findbugs_version = 3.0.2
 lazydfu_version = 0.1.2
-modmenu_version = 3.0.1
+modmenu_version = 3.1.0
 cloth_version = 6.1.48
 toml4j_version = 0.7.2

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,6 +6,5 @@ pluginManagement {
         }
         maven { url = "https://maven.quiltmc.org/repository/release" }
         gradlePluginPortal()
-        mavenLocal()
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,11 +1,11 @@
 pluginManagement {
     repositories {
-        jcenter()
         maven {
             name = 'Fabric'
             url = 'https://maven.fabricmc.net/'
         }
         maven { url = "https://maven.quiltmc.org/repository/release" }
         gradlePluginPortal()
+        mavenLocal()
     }
 }

--- a/src/main/java/dynamicfps/mixin/SoundManagerAccessor.java
+++ b/src/main/java/dynamicfps/mixin/SoundManagerAccessor.java
@@ -1,0 +1,12 @@
+package dynamicfps.mixin;
+
+import net.minecraft.client.sound.SoundManager;
+import net.minecraft.client.sound.SoundSystem;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(SoundManager.class)
+public interface SoundManagerAccessor {
+    @Accessor
+    SoundSystem getSoundSystem();
+}

--- a/src/main/java/dynamicfps/util/KeyBindingHandler.java
+++ b/src/main/java/dynamicfps/util/KeyBindingHandler.java
@@ -3,20 +3,20 @@ package dynamicfps.util;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
 import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
 import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.option.KeyBinding;
-import net.minecraft.client.util.InputUtil;
+import net.minecraft.client.option.KeyBind;
+import com.mojang.blaze3d.platform.InputUtil;
 
 public final class KeyBindingHandler implements ClientTickEvents.EndTick {
-	private final KeyBinding keyBinding;
+	private final KeyBind keyBinding;
 	private boolean isHoldingKey = false;
 	private final PressHandler pressHandler;
 	
 	public KeyBindingHandler(String translationKey, String category, PressHandler pressHandler) {
-		this(translationKey, InputUtil.UNKNOWN_KEY.getCode(), category, pressHandler);
+		this(translationKey, InputUtil.UNKNOWN_KEY.getKeyCode(), category, pressHandler);
 	}
 	
 	public KeyBindingHandler(String translationKey, int defaultKeyCode, String category, PressHandler pressHandler) {
-		this.keyBinding = new KeyBinding(
+		this.keyBinding = new KeyBind(
 			translationKey,
 			InputUtil.Type.KEYSYM,
 			defaultKeyCode,


### PR DESCRIPTION
Instead of *actually* setting it to 0, just pause it instead.

Fixes #55
Also updates to 1.18.2, because quilt mappings for 1.18.1 is no longer available on the maven
~~`quilt-mappings-on-loom` 3.1.1 is also not available, but i got that to build to mavenLocal.~~ Fixed!
Still works on 1.18.1.