### PR TITLE
Delay toasts while user is inactive

### DIFF
--- a/src/main/java/dynamicfps/DynamicFPSMod.java
+++ b/src/main/java/dynamicfps/DynamicFPSMod.java
@@ -78,7 +78,11 @@ public class DynamicFPSMod implements ModInitializer {
 		lastRender = currentTime;
 		return true;
 	}
-	
+
+	public static boolean shouldShowToasts() {
+		return isDisabled || FlawlessFrames.isActive() || fpsOverride() == null;
+	}
+
 	private static boolean wasFocused = true;
 	private static boolean wasVisible = true;
 	private static void checkForStateChanges() {

--- a/src/main/java/dynamicfps/mixin/ToastManagerMixin.java
+++ b/src/main/java/dynamicfps/mixin/ToastManagerMixin.java
@@ -1,0 +1,19 @@
+package dynamicfps.mixin;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import dynamicfps.DynamicFPSMod;
+import net.minecraft.client.toast.ToastManager;
+
+@Mixin(ToastManager.class)
+public class ToastManagerMixin {
+    @Inject(method = "draw", at = @At("HEAD"), cancellable = true)
+    private void onDraw(CallbackInfo callbackInfo) {
+        if (!DynamicFPSMod.shouldShowToasts()) {
+			callbackInfo.cancel();
+		}
+    }
+}

--- a/src/main/resources/dynamicfps.mixins.json
+++ b/src/main/resources/dynamicfps.mixins.json
@@ -7,7 +7,8 @@
   "client": [
     "GameRendererMixin",
     "SplashOverlayMixin",
-    "ThreadExecutorMixin"
+    "ThreadExecutorMixin",
+    "ToastManagerMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
Resolves #72.

I was not sure whether I should add two additional config options for this, so I've opted to simply delay toasts while the mod is actively reducing the frame rate. If this should be changed please let me know!