### PR TITLE
Stop rendering the world while screens are obscuring the whole window

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,7 @@ Dynamic FPS automatically reduces the speed at which minecraft renders when it's
 
 Download in [the releases section](https://github.com/juliand665/Dynamic-FPS/releases), on [Modrinth](https://modrinth.com/mod/dynamic-fps), or on [CurseForge](https://www.curseforge.com/minecraft/mc-mods/dynamic-fps).
 
+## Developer Info
+
+Dynamic FPS can optimize the game while a screen is actively obscuring the world.  
+To make use of this feature your screen must call [`renderDirtBackground`](# "Mojang Mappings") / [`renderBackgroundTexture`](# "Quilt Mappings / Yarn") during rendering.

--- a/README.md
+++ b/README.md
@@ -4,11 +4,17 @@
 
 # Dynamic FPS
 
-Dynamic FPS automatically reduces the speed at which minecraft renders when it's not focused (to 1 FPS) or hidden (no renders at all). It also fixes a bug in Vanilla Minecraft that makes it take much more performance in the background than it should.
+Dynamic FPS automatically reduces the speed at which Minecraft renders when it's not focused (to 1 FPS) or hidden (no renders at all). It also fixes a bug in Vanilla Minecraft that makes it take much more performance in the background than it should.
 
 Download in [the releases section](https://github.com/juliand665/Dynamic-FPS/releases), on [Modrinth](https://modrinth.com/mod/dynamic-fps), or on [CurseForge](https://www.curseforge.com/minecraft/mc-mods/dynamic-fps).
 
 ## Developer Info
 
 Dynamic FPS can optimize the game while a screen is actively obscuring the world.  
-To make use of this feature your screen must call [`renderDirtBackground`](# "Mojang Mappings") / [`renderBackgroundTexture`](# "Quilt Mappings / Yarn") during rendering.
+There are two ways of opting in or out of this feature, either of which may be more applicable to your situation:
+
+- Screens calling [`renderDirtBackground`](# "Mojang Mappings") / [`renderBackgroundTexture`](# "Quilt Mappings / Yarn") during rendering are opted in automatically
+- Mods can provide a list of screens they'd like to opt in or out via their mod metadata ([Fabric Example] / [Quilt Example])
+
+[Fabric Example]: https://gist.github.com/LostLuma/3058c596e15e70671750fe348ff3aff1#file-fabric-mod-json-L42-L49
+[Quilt Example]: https://gist.github.com/LostLuma/3058c596e15e70671750fe348ff3aff1#file-quilt-mod-json-L40-L47

--- a/src/main/java/dynamicfps/DynamicFPSMod.java
+++ b/src/main/java/dynamicfps/DynamicFPSMod.java
@@ -188,8 +188,4 @@ public class DynamicFPSMod implements ModInitializer {
 		if (config.reduceFPSWhenUnfocused && !client.isWindowFocused()) return config.unfocusedFPS;
 		return null;
 	}
-	
-	public interface SplashOverlayAccessor {
-		boolean isReloadComplete();
-	}
 }

--- a/src/main/java/dynamicfps/mixin/GameRendererMixin.java
+++ b/src/main/java/dynamicfps/mixin/GameRendererMixin.java
@@ -1,9 +1,7 @@
 package dynamicfps.mixin;
 
 import dynamicfps.DynamicFPSMod;
-import dynamicfps.DynamicFPSMod.SplashOverlayAccessor;
 import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.gui.screen.Overlay;
 import net.minecraft.client.gui.screen.SplashOverlay;
 import net.minecraft.client.render.GameRenderer;
 import org.spongepowered.asm.mixin.*;
@@ -16,7 +14,7 @@ public class GameRendererMixin {
 	@Shadow
 	@Final
 	private MinecraftClient client;
-	
+
 	/**
 	 Implements the mod's big feature.
 	 */
@@ -26,18 +24,17 @@ public class GameRendererMixin {
 			callbackInfo.cancel();
 		}
 	}
-	
-	/**
-	 cancels world rendering under certain conditions
+
+	/*
+	 * Cancels rendering the world if a screen is covering the whole window or a splash overlay is present.
 	 */
+	@SuppressWarnings("squid:S1871") // Multiple conditions, same code
 	@Inject(at = @At("HEAD"), method = "renderWorld", cancellable = true)
 	private void onRenderWorld(CallbackInfo callbackInfo) {
-		Overlay overlay = client.getOverlay();
-		if (overlay instanceof SplashOverlay) {
-			SplashOverlayAccessor splashScreen = (SplashOverlayAccessor) overlay;
-			if (!splashScreen.isReloadComplete()) {
-				callbackInfo.cancel();
-			}
+		if (client.currentScreen != null && client.currentScreen.dynamicfps$rendersBackground()) {
+			callbackInfo.cancel();
+		} else if (client.getOverlay() instanceof SplashOverlay splashScreen && splashScreen.dynamicfps$isReloadComplete()) {
+			callbackInfo.cancel();
 		}
 	}
 }

--- a/src/main/java/dynamicfps/mixin/MinecraftClientMixin.java
+++ b/src/main/java/dynamicfps/mixin/MinecraftClientMixin.java
@@ -1,0 +1,33 @@
+package dynamicfps.mixin;
+
+import javax.annotation.Nullable;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.screen.Screen;
+
+@Mixin(MinecraftClient.class)
+public class MinecraftClientMixin {
+	@Shadow
+	@Nullable
+	public Screen currentScreen;
+
+	// Default framerate limit on main menu etc.
+	private static final int MENU_FRAMERATE_LIMIT = 60;
+
+	/*
+	 * Sets a framerate limit when a screen is covering the full window.
+	 */
+	@Inject(method = "getFramerateLimit", at = @At("RETURN"), cancellable = true)
+	private void onGetFramerateLimit(CallbackInfoReturnable<Integer> callbackInfo) {
+		if (this.currentScreen != null && this.currentScreen.dynamicfps$rendersBackground()) {
+			// Keep the existing framerate limit if the user has set the game to run at eg. 30 FPS
+			callbackInfo.setReturnValue(Math.min(callbackInfo.getReturnValue(), MENU_FRAMERATE_LIMIT));
+		}
+	}
+}

--- a/src/main/java/dynamicfps/mixin/ScreenMixin.java
+++ b/src/main/java/dynamicfps/mixin/ScreenMixin.java
@@ -7,27 +7,34 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import dynamicfps.util.DynamicFPSScreen;
-import net.minecraft.client.gui.screen.DownloadingTerrainScreen;
+import dynamicfps.util.ScreenOptimizationCompat;
 import net.minecraft.client.gui.screen.Screen;
 
 @Mixin(Screen.class)
 public class ScreenMixin implements DynamicFPSScreen {
 	@Unique
-	private boolean dynamicfps$rendersBackground = false;
+	private boolean dynamicfps$canOptimize = false;
+
+	@Unique
+	private boolean dynamicfps$hasOptedOut = false;
 
 	@Override
 	public boolean dynamicfps$rendersBackground() {
-		return dynamicfps$rendersBackground;
+		return dynamicfps$canOptimize;
+	}
+
+	@Inject(method = "init", at = @At("HEAD"))
+	private void onInit(CallbackInfo callbackInfo) {
+		String name = this.getClass().getName();
+
+		this.dynamicfps$canOptimize = ScreenOptimizationCompat.isOptedIn(name);
+		this.dynamicfps$hasOptedOut = ScreenOptimizationCompat.isOptedOut(name);
 	}
 
 	@Inject(method = "renderBackgroundTexture", at = @At("HEAD"))
 	private void onRenderBackgroundTexture(CallbackInfo callbackInfo) {
-		// This screen is not compatible with this optimization,
-		// As it waits for chunks to be done rendering to close.
-		if ((Screen)(Object)this instanceof DownloadingTerrainScreen) {
-			return;
+		if (!this.dynamicfps$hasOptedOut) {
+			this.dynamicfps$canOptimize = true; // Signal to apply optimizations on next frame
 		}
-
-		this.dynamicfps$rendersBackground = true; // Signal to apply optimizations on next frame
 	}
 }

--- a/src/main/java/dynamicfps/mixin/ScreenMixin.java
+++ b/src/main/java/dynamicfps/mixin/ScreenMixin.java
@@ -1,0 +1,33 @@
+package dynamicfps.mixin;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import dynamicfps.util.DynamicFPSScreen;
+import net.minecraft.client.gui.screen.DownloadingTerrainScreen;
+import net.minecraft.client.gui.screen.Screen;
+
+@Mixin(Screen.class)
+public class ScreenMixin implements DynamicFPSScreen {
+	@Unique
+	private boolean dynamicfps$rendersBackground = false;
+
+	@Override
+	public boolean dynamicfps$rendersBackground() {
+		return dynamicfps$rendersBackground;
+	}
+
+	@Inject(method = "renderBackgroundTexture", at = @At("HEAD"))
+	private void onRenderBackgroundTexture(CallbackInfo callbackInfo) {
+		// This screen is not compatible with this optimization,
+		// As it waits for chunks to be done rendering to close.
+		if ((Screen)(Object)this instanceof DownloadingTerrainScreen) {
+			return;
+		}
+
+		this.dynamicfps$rendersBackground = true; // Signal to apply optimizations on next frame
+	}
+}

--- a/src/main/java/dynamicfps/mixin/ScreenMixin.java
+++ b/src/main/java/dynamicfps/mixin/ScreenMixin.java
@@ -27,8 +27,13 @@ public class ScreenMixin implements DynamicFPSScreen {
 	private void onInit(CallbackInfo callbackInfo) {
 		String name = this.getClass().getName();
 
-		this.dynamicfps$canOptimize = ScreenOptimizationCompat.isOptedIn(name);
 		this.dynamicfps$hasOptedOut = ScreenOptimizationCompat.isOptedOut(name);
+
+		// Allow other mods to opt out on behalf of vanilla screens
+		// That Dynamic FPS forced to opt in via its own mod metadata.
+		if (!this.dynamicfps$hasOptedOut) {
+			this.dynamicfps$canOptimize = ScreenOptimizationCompat.isOptedIn(name);
+		}
 	}
 
 	@Inject(method = "renderBackgroundTexture", at = @At("HEAD"))

--- a/src/main/java/dynamicfps/mixin/SplashOverlayMixin.java
+++ b/src/main/java/dynamicfps/mixin/SplashOverlayMixin.java
@@ -1,17 +1,17 @@
 package dynamicfps.mixin;
 
-import dynamicfps.DynamicFPSMod.SplashOverlayAccessor;
+import dynamicfps.util.DynamicFPSSplashOverlay;
 import net.minecraft.client.gui.screen.SplashOverlay;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 
 @Mixin(SplashOverlay.class)
-public class SplashOverlayMixin implements SplashOverlayAccessor {
+public class SplashOverlayMixin implements DynamicFPSSplashOverlay {
 	@Shadow
 	private long reloadCompleteTime;
 	
 	@Override
-	public boolean isReloadComplete() {
+	public boolean dynamicfps$isReloadComplete() {
 		return reloadCompleteTime > -1L;
 	}
 }

--- a/src/main/java/dynamicfps/util/DynamicFPSScreen.java
+++ b/src/main/java/dynamicfps/util/DynamicFPSScreen.java
@@ -1,0 +1,7 @@
+package dynamicfps.util;
+
+public interface DynamicFPSScreen {
+	public default boolean dynamicfps$rendersBackground() {
+		throw new RuntimeException("Dynamic FPS' Screen mixin was not applied.");
+	}
+}

--- a/src/main/java/dynamicfps/util/DynamicFPSSplashOverlay.java
+++ b/src/main/java/dynamicfps/util/DynamicFPSSplashOverlay.java
@@ -1,0 +1,7 @@
+package dynamicfps.util;
+
+public interface DynamicFPSSplashOverlay {
+	public default boolean dynamicfps$isReloadComplete() {
+		throw new RuntimeException("Dynamic FPS' SplashOverlay mixin was not applied.");
+	}
+}

--- a/src/main/java/dynamicfps/util/ScreenOptimizationCompat.java
+++ b/src/main/java/dynamicfps/util/ScreenOptimizationCompat.java
@@ -1,0 +1,61 @@
+package dynamicfps.util;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.annotation.Nullable;
+
+import net.fabricmc.loader.api.FabricLoader;
+import net.fabricmc.loader.api.MappingResolver;
+import net.fabricmc.loader.api.ModContainer;
+import net.fabricmc.loader.api.metadata.CustomValue;
+import net.fabricmc.loader.api.metadata.ModMetadata;
+import net.fabricmc.loader.api.metadata.CustomValue.CvObject;
+import net.fabricmc.loader.api.metadata.CustomValue.CvType;
+
+public class ScreenOptimizationCompat {
+    private static Set<String> optedInScreens = new HashSet<>();
+    private static Set<String> optedOutScreens = new HashSet<>();
+
+    static {
+        FabricLoader.getInstance().getAllMods().forEach(ScreenOptimizationCompat::parseModMetadata);
+    }
+
+    public static boolean isOptedIn(String className) {
+        return optedInScreens.contains(className);
+    }
+
+    public static boolean isOptedOut(String className) {
+        return optedOutScreens.contains(className);
+    }
+
+    private static void parseModMetadata(ModContainer mod) {
+        CvObject optimizedScreens;
+        ModMetadata data = mod.getMetadata();
+
+        try {
+            var root = data.getCustomValue("dynamic_fps").getAsObject();
+            optimizedScreens = root.get("optimized_screens").getAsObject();
+        } catch (ClassCastException | NullPointerException e) {
+            return;  // Object is either missing or is of an invalid type
+        }
+
+        var resolver = FabricLoader.getInstance().getMappingResolver();
+
+        addToSet(resolver, optimizedScreens.get("enabled"), optedInScreens);
+        addToSet(resolver, optimizedScreens.get("disabled"), optedOutScreens);
+    }
+
+    private static void addToSet(MappingResolver resolver, @Nullable CustomValue values, Set<String> set) {
+        if (values == null || values.getType() != CvType.ARRAY) {
+            return;
+        }
+
+        values.getAsArray().forEach(value -> {
+            if (value.getType() == CvType.STRING) {
+                // Translate from intermediary to runtime names for vanilla screens
+                set.add(resolver.mapClassName("intermediary", value.getAsString()));
+            }
+        });
+    }
+}

--- a/src/main/resources/dynamicfps.mixins.json
+++ b/src/main/resources/dynamicfps.mixins.json
@@ -6,6 +6,8 @@
   ],
   "client": [
     "GameRendererMixin",
+    "MinecraftClientMixin",
+    "ScreenMixin",
     "SplashOverlayMixin",
     "ThreadExecutorMixin",
     "ToastManagerMixin"

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -37,5 +37,12 @@
 		"fabric-rendering-v1": "*",
 		"fabric-lifecycle-events-v1": "*",
 		"fabric-key-binding-api-v1": "*"
+	},
+
+	"custom": {
+		"loom:injected_interfaces": {
+			"net/minecraft/class_437": ["dynamicfps/util/DynamicFPSScreen"],
+			"net/minecraft/class_425": ["dynamicfps/util/DynamicFPSSplashOverlay"]
+		}
 	}
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -43,6 +43,41 @@
 		"loom:injected_interfaces": {
 			"net/minecraft/class_437": ["dynamicfps/util/DynamicFPSScreen"],
 			"net/minecraft/class_425": ["dynamicfps/util/DynamicFPSSplashOverlay"]
+		},
+		"dynamic_fps": {
+			"optimized_screens": {
+				"enabled": [
+					"net.minecraft.class_445",
+					"net.minecraft.class_4189",
+					"net.minecraft.class_404",
+					"net.minecraft.class_6599",
+					"net.minecraft.class_426",
+					"net.minecraft.class_4288",
+					"net.minecraft.class_6777",
+					"net.minecraft.class_443",
+					"net.minecraft.class_446"
+				],
+				"disabled": [
+					"net.minecraft.class_434"
+				],
+				"_comment": {
+					"_": "Quilt Mapping names of the enabled / disabled screens. Not needed for mod screens.",
+					"enabled": {
+						"net.minecraft.class_445": "net.minecraft.client.gui.screen.CreditsScreen",
+						"net.minecraft.class_4189": "net.minecraft.client.gui.screen.option.AccessibilityOptionsScreen",
+						"net.minecraft.class_404": "net.minecraft.client.gui.screen.option.ChatOptionsScreen",
+						"net.minecraft.class_6599": "net.minecraft.client.gui.screen.option.KeyBindsScreen",
+						"net.minecraft.class_426": "net.minecraft.client.gui.screen.option.LanguageOptionsScreen",
+						"net.minecraft.class_4288": "net.minecraft.client.gui.screen.option.MouseOptionsScreen",
+						"net.minecraft.class_6777": "net.minecraft.client.gui.screen.option.OnlineOptionsScreen",
+						"net.minecraft.class_443": "net.minecraft.client.gui.screen.option.SoundOptionsScreen",
+						"net.minecraft.class_446": "net.minecraft.client.gui.screen.option.VideoOptionsScreen"
+					},
+					"disabled": {
+						"net.minecraft.class_434": "net.minecraft.client.gui.screen.DownloadingTerrainScreen"
+					}
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
Applies two new optimizations while a screen is obscuring the game:
- Limits framerate to 60, same as vanilla main menu etc.
- Stops rendering the world behind the screen, as it's not visible

This implements #68, however as the only way I could think of to detect that a screen is covering the whole window is whether it renders the background image this optimization sadly does not apply to about half of the vanilla options screens since they are rendered differently. An upside however is that the cloth config screen used by many mods such as this one is affected!

I'm opening this as a PR so it can be tested first by some people to see if this breaks any mods (which I doubt, given how simple this is). You can find a built version here: [dynamic-fps-2.3.0-dirty-screen-optimization.jar](https://files.lostluma.net/dynamic-fps-2.3.0-dirty-screen-optimization.jar)

cc @Felix14-v2 and anyone else interested 🐈