### PR TITLE
Simplify toast delaying to fix toasts disappearing on window unfocus

### DIFF
--- a/src/main/java/dynamicfps/mixin/ToastComponentMixin.java
+++ b/src/main/java/dynamicfps/mixin/ToastComponentMixin.java
@@ -3,17 +3,17 @@ package dynamicfps.mixin;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import dynamicfps.DynamicFPSMod;
 import net.minecraft.client.gui.components.toasts.ToastComponent;
 
 @Mixin(ToastComponent.class)
 public class ToastComponentMixin {
-    @Inject(method = "render", at = @At("HEAD"), cancellable = true)
-    private void onRender(CallbackInfo callbackInfo) {
-        if (!DynamicFPSMod.shouldShowToasts()) {
-			callbackInfo.cancel();
+	@Inject(method = "freeSlots", at = @At("HEAD"), cancellable = true)
+	private void onFreeSlots(CallbackInfoReturnable<Integer> callbackInfo) {
+		if (!DynamicFPSMod.shouldShowToasts()) {
+			callbackInfo.setReturnValue(0);
 		}
-    }
+	}
 }


### PR DESCRIPTION
Previously unfocusing the window made toasts simply disappear, now they will disappear as normal but new ones will not be added as the game will think there are already enough toasts. I'm unsure how I missed this originally, this is obviously a lot better .. 🙂