### PR TITLE
Apply screen optimization to stats screen

### DIFF
--- a/src/main/java/dynamicfps/mixin/ScreenMixin.java
+++ b/src/main/java/dynamicfps/mixin/ScreenMixin.java
@@ -23,6 +23,11 @@ public class ScreenMixin implements DynamicFPSScreen {
 		return dynamicfps$canOptimize;
 	}
 
+	@Override
+	public void dynamicfps$setRendersBackground(boolean value) {
+		this.dynamicfps$canOptimize = value;
+	}
+
 	@Inject(method = "init", at = @At("HEAD"))
 	private void onInit(CallbackInfo callbackInfo) {
 		String name = this.getClass().getName();

--- a/src/main/java/dynamicfps/mixin/StatsScreenMixin.java
+++ b/src/main/java/dynamicfps/mixin/StatsScreenMixin.java
@@ -1,0 +1,18 @@
+package dynamicfps.mixin;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.gui.screens.achievement.StatsScreen;
+
+@Mixin(StatsScreen.class)
+public class StatsScreenMixin {
+	@Inject(method = "onStatsUpdated", at = @At("HEAD"))
+	private void onStatsUpdated(CallbackInfo callbackInfo) {
+		Screen screen = (Screen)(Object)this;
+		screen.dynamicfps$setRendersBackground(true);
+	}
+}

--- a/src/main/java/dynamicfps/util/DynamicFPSScreen.java
+++ b/src/main/java/dynamicfps/util/DynamicFPSScreen.java
@@ -4,4 +4,8 @@ public interface DynamicFPSScreen {
 	public default boolean dynamicfps$rendersBackground() {
 		throw new RuntimeException("Dynamic FPS' Screen mixin was not applied.");
 	}
+
+	public default void dynamicfps$setRendersBackground(boolean value) {
+		throw new RuntimeException("Dynamic FPS' Screen mixin was not applied.");
+	}
 }

--- a/src/main/resources/dynamicfps.mixins.json
+++ b/src/main/resources/dynamicfps.mixins.json
@@ -1,18 +1,18 @@
 {
-  "required": true,
-  "package": "dynamicfps.mixin",
-  "compatibilityLevel": "JAVA_17",
-  "mixins": [
-  ],
-  "client": [
-    "GameRendererMixin",
-    "LoadingOverlayMixin",
-    "MinecraftMixin",
-    "ScreenMixin",
-    "ToastComponentMixin",
-    "bugfix.BlockableEventLoopMixin"
-  ],
-  "injectors": {
-    "defaultRequire": 1
-  }
+	"required": true,
+	"package": "dynamicfps.mixin",
+	"compatibilityLevel": "JAVA_17",
+	"mixins": [],
+	"client": [
+		"GameRendererMixin",
+		"LoadingOverlayMixin",
+		"MinecraftMixin",
+		"ScreenMixin",
+		"StatsScreenMixin",
+		"ToastComponentMixin",
+		"bugfix.BlockableEventLoopMixin"
+	],
+	"injectors": {
+		"defaultRequire": 1
+	}
 }


### PR DESCRIPTION
Applies screen optimization once the screen is no longer transparent (the stats packet has been received from the server).