### PR TITLE
Add information about reduced frame rate to debug screen

### DIFF
--- a/src/main/java/dynamic_fps/impl/mixin/DebugScreenOverlayMixin.java
+++ b/src/main/java/dynamic_fps/impl/mixin/DebugScreenOverlayMixin.java
@@ -1,0 +1,31 @@
+package dynamic_fps.impl.mixin;
+
+import java.util.List;
+import java.util.Locale;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import dynamic_fps.impl.DynamicFPSMod;
+import dynamic_fps.impl.PowerState;
+import net.minecraft.client.gui.components.DebugScreenOverlay;
+
+@Mixin(DebugScreenOverlay.class)
+public class DebugScreenOverlayMixin {
+	/*
+	 * Insert information about effective frame rate below misleading FPS counter.
+	 */
+	@Inject(method = "getGameInformation", at = @At("RETURN"))
+	private void onGetGameInformation(CallbackInfoReturnable<List<String>> callbackInfo) {
+		var status = DynamicFPSMod.powerState();
+
+		if (status != PowerState.FOCUSED) {
+			var result = callbackInfo.getReturnValue();
+			int target = DynamicFPSMod.targetFrameRate();
+
+			result.add(2, String.format(Locale.ROOT, "§c[Dynamic FPS] FPS: %s P: %s§r", target, status.toString().toLowerCase()));
+		}
+	}
+}

--- a/src/main/resources/dynamic_fps.mixins.json
+++ b/src/main/resources/dynamic_fps.mixins.json
@@ -4,6 +4,7 @@
 	"compatibilityLevel": "JAVA_17",
 	"mixins": [],
 	"client": [
+		"DebugScreenOverlayMixin",
 		"GameRendererMixin",
 		"GuiMixin",
 		"LoadingOverlayMixin",


### PR DESCRIPTION
Resolves #76 by adding a new debug line right under the FPS indicator, but maybe it should be elsewhere(?)
I've decided to use a *very obvious color* for this since it will only display while **not focused** to not be intrusive.

We do not replace the FPS display so other mods can change the way it displays (eg. as frame times, which I've seen mentioned).

![](https://files.lostluma.net/DEdzQY.png)

I've also added the current power state to this line so it's easier to figure out what the mod is doing, or learn how it works.
