### PR TITLE
Fix incompatibility with Fabrication's uncap_menu_fps option

### DIFF
--- a/src/main/java/dynamic_fps/impl/mixin/MinecraftMixin.java
+++ b/src/main/java/dynamic_fps/impl/mixin/MinecraftMixin.java
@@ -4,7 +4,6 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import dynamic_fps.impl.DynamicFPSMod;
 import net.minecraft.client.Minecraft;
@@ -14,16 +13,5 @@ public class MinecraftMixin {
 	@Inject(method = "runTick", at = @At("HEAD"))
 	private void onRunTick(CallbackInfo callbackInfo) {
 		DynamicFPSMod.onNewFrame();
-	}
-
-	/*
-	 * Sets a frame rate limit while it is lowered synthetically or a menu-type screen is open.
-	 */
-	@Inject(method = "getFramerateLimit", at = @At("RETURN"), cancellable = true)
-	private void onGetFramerateLimit(CallbackInfoReturnable<Integer> callbackInfo) {
-		if (DynamicFPSMod.shouldReduceFramerate()) {
-			// Keep the existing frame rate limit if the user has set the game to run at eg. 30 FPS
-			callbackInfo.setReturnValue(Math.min(callbackInfo.getReturnValue(), DynamicFPSMod.MENU_FRAMERATE_LIMIT));
-		}
 	}
 }

--- a/src/main/java/dynamic_fps/impl/mixin/WindowMixin.java
+++ b/src/main/java/dynamic_fps/impl/mixin/WindowMixin.java
@@ -1,0 +1,24 @@
+package dynamic_fps.impl.mixin;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import com.mojang.blaze3d.platform.Window;
+
+import dynamic_fps.impl.DynamicFPSMod;
+
+@Mixin(Window.class)
+public class WindowMixin {
+	/*
+	 * Sets a frame rate limit while it is lowered synthetically or a menu-type screen is open.
+	 */
+	@Inject(method = "getFramerateLimit", at = @At("RETURN"), cancellable = true)
+	private void onGetFramerateLimit(CallbackInfoReturnable<Integer> callbackInfo) {
+		if (DynamicFPSMod.shouldReduceFramerate()) {
+			// Keep the existing frame rate limit if the user has set the game to run at eg. 30 FPS
+			callbackInfo.setReturnValue(Math.min(callbackInfo.getReturnValue(), DynamicFPSMod.MENU_FRAMERATE_LIMIT));
+		}
+	}
+}

--- a/src/main/resources/dynamic_fps.mixins.json
+++ b/src/main/resources/dynamic_fps.mixins.json
@@ -12,6 +12,7 @@
 		"ScreenMixin",
 		"StatsScreenMixin",
 		"ToastComponentMixin",
+		"WindowMixin",
 		"bugfix.BlockableEventLoopMixin"
 	],
 	"injectors": {


### PR DESCRIPTION
Fixes #105 by making Fabrication pull the frame rate limit from Dynamic FPS instead of bypassing us.
