### PR TITLE
Special case suspend limit of 60 FPS to fix other mods' rendering

### DIFF
--- a/src/main/java/dynamic_fps/impl/DynamicFPSMod.java
+++ b/src/main/java/dynamic_fps/impl/DynamicFPSMod.java
@@ -233,6 +233,13 @@ public class DynamicFPSMod implements ClientModInitializer {
 			return frameRateTarget == -1;
 		}
 
+		// Minecraft is limited to 60,
+		// No need to cancel some frames.
+		// Fixes #107 (Xaero's World Map)
+		if (frameRateTarget == 60) {
+			return true;
+		}
+
 		// Render one more frame before
 		// Applying the custom frame rate
 		// So changes show up immediately


### PR DESCRIPTION
Fixes #107.

Xaero's screen rendering doesn't like (sometimes/most times) being cancelled due to the suspended power state limit, I assume other mods would also not like it so we will rely on the Minecraft FPS limiter instead as it's already locked to 60.