### PR TITLE
Use window events instead of polling for changes every frame

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,6 +3,6 @@ org.gradle.parallel = true
 org.gradle.jvmargs = -Xmx1G
 
 # Mod Properties
-mod_version = 3.0.1
+mod_version = 3.1.0
 maven_group = juliand665
 archives_base_name = dynamic-fps

--- a/src/main/java/dynamic_fps/impl/DynamicFPSMod.java
+++ b/src/main/java/dynamic_fps/impl/DynamicFPSMod.java
@@ -8,6 +8,7 @@ import dynamic_fps.impl.util.KeyMappingHandler;
 import dynamic_fps.impl.util.Logging;
 import dynamic_fps.impl.util.ModCompatibility;
 import dynamic_fps.impl.util.OptionsHolder;
+import dynamic_fps.impl.util.WindowObserver;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.rendering.v1.HudRenderCallback;
 import net.fabricmc.loader.api.FabricLoader;
@@ -15,10 +16,6 @@ import net.minecraft.Util;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.LoadingOverlay;
 import net.minecraft.sounds.SoundSource;
-
-import org.lwjgl.glfw.GLFW;
-
-import com.mojang.blaze3d.platform.Window;
 
 import static dynamic_fps.impl.util.Localization.translationKey;
 
@@ -39,8 +36,8 @@ public class DynamicFPSMod implements ClientModInitializer {
 	private static boolean isDisabled = false;
 	private static boolean isForcingLowFPS = false;
 
-	private static Window window;
 	private static Minecraft minecraft;
+	private static WindowObserver window;
 
 	private static long lastRender;
 
@@ -55,12 +52,18 @@ public class DynamicFPSMod implements ClientModInitializer {
 	private static final KeyMappingHandler toggleForcedKeyBinding = new KeyMappingHandler(
 			translationKey("key", "toggle_forced"),
 			"key.categories.misc",
-			() -> isForcingLowFPS = !isForcingLowFPS);
+			() -> {
+				isForcingLowFPS = !isForcingLowFPS;
+				onStatusChanged();
+			});
 
 	private static final KeyMappingHandler toggleDisabledKeyBinding = new KeyMappingHandler(
 			translationKey("key", "toggle_disabled"),
 			"key.categories.misc",
-			() -> isDisabled = !isDisabled);
+			() -> {
+				isDisabled = !isDisabled;
+				onStatusChanged();
+			});
 
 	@Override
 	public void onInitializeClient() {
@@ -74,17 +77,12 @@ public class DynamicFPSMod implements ClientModInitializer {
 
 	// Internal "API" for Dynamic FPS itself
 
-	public static void onNewFrame() {
-		if (window == null) {
-			minecraft = Minecraft.getInstance();
-			window = minecraft.getWindow();
-		}
-
-		checkForStateChanges();
-	}
-
 	public static boolean isDisabled() {
 		return isDisabled;
+	}
+
+	public static void onStatusChanged() {
+		checkForStateChanges();
 	}
 
 	public static PowerState powerState() {
@@ -93,6 +91,10 @@ public class DynamicFPSMod implements ClientModInitializer {
 
 	public static boolean isForcingLowFPS() {
 		return isForcingLowFPS;
+	}
+
+	public static void setWindow(long address) {
+		window = new WindowObserver(address);
 	}
 
 	public static boolean checkForRender() {
@@ -112,7 +114,7 @@ public class DynamicFPSMod implements ClientModInitializer {
 	}
 
 	public static boolean shouldShowToasts() {
-		return isDisabledInternal() || config.showToasts();
+		return config.showToasts();
 	}
 
 	public static boolean shouldShowLevels() {
@@ -170,30 +172,32 @@ public class DynamicFPSMod implements ClientModInitializer {
 	}
 
 	private static void checkForStateChanges() {
+		if (window == null) {
+			return;
+		}
+
+		if (minecraft == null) {
+			minecraft = Minecraft.getInstance();
+		}
+
 		PowerState current;
 
 		if (isDisabledInternal()) {
 			current = PowerState.FOCUSED;
 		} else if (isForcingLowFPS) {
 			current = PowerState.UNFOCUSED;
-		} else {
-			var isFocused = minecraft.isWindowActive();
-			var isHovered = GLFW.glfwGetWindowAttrib(window.getWindow(), GLFW.GLFW_HOVERED) != 0;
-			var isVisible = GLFW.glfwGetWindowAttrib(window.getWindow(), GLFW.GLFW_VISIBLE) != 0 && GLFW.glfwGetWindowAttrib(window.getWindow(), GLFW.GLFW_ICONIFIED) == 0;
-
-			if (isFocused) {
-				if (!isPauseScreenOpened()) {
-					current = PowerState.FOCUSED;
-				} else {
-					current = PowerState.SUSPENDED;
-				}
-			} else if (isHovered) {
-				current = PowerState.HOVERED;
-			} else if (isVisible) {
-				current = PowerState.UNFOCUSED;
+		} else if (window.isFocused()) {
+			if (!isPauseScreenOpened()) {
+				current = PowerState.FOCUSED;
 			} else {
-				current = PowerState.INVISIBLE;
+				current = PowerState.SUSPENDED;
 			}
+		} else if (window.isHovered()) {
+			current = PowerState.HOVERED;
+		} else if (!window.isIconified()) {
+			current = PowerState.UNFOCUSED;
+		} else {
+			current = PowerState.INVISIBLE;
 		}
 
 		if (state != current) {

--- a/src/main/java/dynamic_fps/impl/compat/FREX.java
+++ b/src/main/java/dynamic_fps/impl/compat/FREX.java
@@ -8,6 +8,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+import dynamic_fps.impl.DynamicFPSMod;
+
 /**
  * <p>
  * Implements the FREX Flawless Frames API to allow other mods to request all
@@ -17,37 +19,39 @@ import java.util.function.Function;
  * See https://github.com/grondag/frex/pull/9
  */
 public final class FREX implements ClientModInitializer {
-    private static final Set<Object> ACTIVE = ConcurrentHashMap.newKeySet();
+	private static final Set<Object> ACTIVE = ConcurrentHashMap.newKeySet();
 
-    private static final class Listener implements Consumer<Boolean> {
-        private final String name;
+	private static final class Listener implements Consumer<Boolean> {
+		private final String name;
 
-        private Listener(String name) {
-            this.name = name;
-        }
+		private Listener(String name) {
+			this.name = name;
+		}
 
-        @Override
-        public void accept(Boolean enabled) {
-            if (enabled) {
-                ACTIVE.add(this.name);
-            } else {
-                ACTIVE.remove(this.name);
-            }
-        }
-    }
+		@Override
+		public void accept(Boolean enabled) {
+			if (enabled) {
+				ACTIVE.add(this.name);
+			} else {
+				ACTIVE.remove(this.name);
+			}
 
-    public interface ListenerConsumer extends Consumer<Function<String, Consumer<Boolean>>> {}
+			DynamicFPSMod.onStatusChanged();
+		}
+	}
 
-    /**
-     * Returns whether one or more mods have requested Flawless Frames to be active,
-     * and therefore frames should not be skipped.
-     */
-    public static boolean isFlawlessFramesActive() {
-        return !ACTIVE.isEmpty();
-    }
+	public interface ListenerConsumer extends Consumer<Function<String, Consumer<Boolean>>> {}
 
-    @Override
-    public void onInitializeClient() {
-        FabricLoader.getInstance().getEntrypoints("frex_flawless_frames", ListenerConsumer.class).forEach(api -> api.accept(Listener::new));
-    }
+	/**
+	 * Returns whether one or more mods have requested Flawless Frames to be active,
+	 * and therefore frames should not be skipped.
+	 */
+	public static boolean isFlawlessFramesActive() {
+		return !ACTIVE.isEmpty();
+	}
+
+	@Override
+	public void onInitializeClient() {
+		FabricLoader.getInstance().getEntrypoints("frex_flawless_frames", ListenerConsumer.class).forEach(api -> api.accept(Listener::new));
+	}
 }

--- a/src/main/java/dynamic_fps/impl/mixin/MinecraftMixin.java
+++ b/src/main/java/dynamic_fps/impl/mixin/MinecraftMixin.java
@@ -10,8 +10,8 @@ import net.minecraft.client.Minecraft;
 
 @Mixin(Minecraft.class)
 public class MinecraftMixin {
-	@Inject(method = "runTick", at = @At("HEAD"))
-	private void onRunTick(CallbackInfo callbackInfo) {
-		DynamicFPSMod.onNewFrame();
+	@Inject(method = "setScreen", at = @At("TAIL"))
+	private void onSetScreen(CallbackInfo callbackInfo) {
+		DynamicFPSMod.onStatusChanged();
 	}
 }

--- a/src/main/java/dynamic_fps/impl/mixin/WindowMixin.java
+++ b/src/main/java/dynamic_fps/impl/mixin/WindowMixin.java
@@ -1,8 +1,11 @@
 package dynamic_fps.impl.mixin;
 
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import com.mojang.blaze3d.platform.Window;
@@ -11,6 +14,15 @@ import dynamic_fps.impl.DynamicFPSMod;
 
 @Mixin(Window.class)
 public class WindowMixin {
+	@Shadow
+	@Final
+	private long window;
+
+	@Inject(method = "<init>", at = @At("TAIL"))
+	private void postinit(CallbackInfo callbackInfo) {
+		DynamicFPSMod.setWindow(this.window);
+	}
+
 	/*
 	 * Sets a frame rate limit while it is lowered synthetically or a menu-type screen is open.
 	 */

--- a/src/main/java/dynamic_fps/impl/util/Logging.java
+++ b/src/main/java/dynamic_fps/impl/util/Logging.java
@@ -1,13 +1,14 @@
 package dynamic_fps.impl.util;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import dynamic_fps.impl.DynamicFPSMod;
 
 public class Logging {
-    private static final Logger logger = LoggerFactory.getLogger(DynamicFPSMod.MOD_ID);
+	private static final Logger logger = LoggerFactory.getLogger(DynamicFPSMod.MOD_ID);
 
-    public static Logger getLogger() {
-        return logger;
-    }
+	public static Logger getLogger() {
+		return logger;
+	}
 }

--- a/src/main/java/dynamic_fps/impl/util/WindowObserver.java
+++ b/src/main/java/dynamic_fps/impl/util/WindowObserver.java
@@ -1,0 +1,80 @@
+package dynamic_fps.impl.util;
+
+import org.lwjgl.glfw.GLFW;
+import org.lwjgl.glfw.GLFWCursorEnterCallback;
+import org.lwjgl.glfw.GLFWWindowFocusCallback;
+import org.lwjgl.glfw.GLFWWindowIconifyCallback;
+
+import dynamic_fps.impl.DynamicFPSMod;
+
+public class WindowObserver {
+	private final long window;
+
+	private boolean isFocused;
+	private final GLFWWindowFocusCallback previousFocusCallback;
+
+	private boolean isHovered;
+	private final GLFWCursorEnterCallback previousMouseCallback;
+
+	private boolean isIconified;
+	private final GLFWWindowIconifyCallback previousIconifyCallback;
+
+	public WindowObserver(long address) {
+		this.window = address;
+
+		previousFocusCallback = GLFW.glfwSetWindowFocusCallback(window, this::onFocusChanged);
+		previousMouseCallback = GLFW.glfwSetCursorEnterCallback(window, this::onMouseChanged);
+
+		// Vanilla doesn't use this (currently), other mods might register this callback though ...
+		previousIconifyCallback = GLFW.glfwSetWindowIconifyCallback(window, this::onIconifyChanged);
+	}
+
+	private boolean isCurrentWindow(long address) {
+		return address == this.window;
+	}
+
+	public boolean isFocused() {
+		return this.isFocused;
+	}
+
+	private void onFocusChanged(long address, boolean focused) {
+		if (isCurrentWindow(address)) {
+			this.isFocused = focused;
+			DynamicFPSMod.onStatusChanged();
+		}
+
+		if (previousFocusCallback != null) {
+			previousFocusCallback.invoke(address, focused);
+		}
+	}
+
+	public boolean isHovered() {
+		return this.isHovered;
+	}
+
+	private void onMouseChanged(long address, boolean hovered) {
+		if (isCurrentWindow(address)) {
+			this.isHovered = hovered;
+			DynamicFPSMod.onStatusChanged();
+		}
+
+		if (previousMouseCallback != null) {
+			previousMouseCallback.invoke(address, hovered);
+		}
+	}
+
+	public boolean isIconified() {
+		return this.isIconified;
+	}
+
+	private void onIconifyChanged(long address, boolean iconified) {
+		if (isCurrentWindow(address)) {
+			this.isIconified = iconified;
+			DynamicFPSMod.onStatusChanged();
+		}
+
+		if (previousIconifyCallback != null) {
+			previousIconifyCallback.invoke(address, iconified);
+		}
+	}
+}


### PR DESCRIPTION
Uses LWJGL and internal Minecraft methods to create an event system instead of polling for changes every frame.
As far as I can tell this seems to work as expected, and should reduce the little overhead Dynamic FPS adds even more.