### PR TITLE
Limit suspended state to pause screen

### DIFF
--- a/src/main/java/dynamic_fps/impl/DynamicFPSMod.java
+++ b/src/main/java/dynamic_fps/impl/DynamicFPSMod.java
@@ -14,6 +14,7 @@ import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.Util;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.LoadingOverlay;
+import net.minecraft.client.gui.screens.PauseScreen;
 import net.minecraft.sounds.SoundSource;
 
 import org.lwjgl.glfw.GLFW;
@@ -118,7 +119,6 @@ public class DynamicFPSMod implements ClientModInitializer {
 	public static boolean shouldShowLevels() {
 		return isDisabledInternal() || !(isLevelCoveredByScreen() || isLevelCoveredByOverlay());
 	}
-
 	public static boolean shouldReduceFramerate() {
 		return !isDisabledInternal() && (config.frameRateTarget() != -1 || isLevelCoveredByScreen());
 	}
@@ -130,7 +130,7 @@ public class DynamicFPSMod implements ClientModInitializer {
 	}
 
 	private static boolean isPauseScreenOpened() {
-		return minecraft.screen != null && minecraft.screen.isPauseScreen();
+		return minecraft.screen instanceof PauseScreen;
 	}
 
 	private static boolean isLevelCoveredByScreen() {

--- a/src/main/java/dynamic_fps/impl/PowerState.java
+++ b/src/main/java/dynamic_fps/impl/PowerState.java
@@ -34,7 +34,7 @@ public enum PowerState {
 	INVISIBLE(true),
 
 	/*
-	 * Singleplayer game is paused by the user.
+	 * User is currently on the pause screen.
 	 */
 	SUSPENDED(false);
 


### PR DESCRIPTION
Fixes #113. Now only applies suspend when on the actual pause screen.
Seems that sadly this experiment wasn't a good experience after all .. 🥲