### PR TITLE
Duplicate language files used for multiple regions

### DIFF
--- a/src/main/resources/assets/dynamic_fps/lang/de_at.json
+++ b/src/main/resources/assets/dynamic_fps/lang/de_at.json
@@ -1,0 +1,21 @@
+{
+	"config.dynamic_fps.title": "Dynamic FPS Konfigurieren",
+
+	"config.dynamic_fps.category.hovered": "Schwebend",
+	"config.dynamic_fps.category.unfocused": "Unfokussiert",
+	"config.dynamic_fps.category.invisible": "Unsichtbar",
+
+	"config.dynamic_fps.frame_rate_target": "Zielbildrate",
+	"config.dynamic_fps.frame_rate_target_description": "Setze die Zielbildrate auf -1 um die Bildrate nicht zu reduzieren.",
+	"config.dynamic_fps.volume_multiplier": "Lautstärke",
+	"config.dynamic_fps.graphics_state": "Grafikoptionen",
+	"config.dynamic_fps.show_toasts": "Toasts Anzeigen",
+	"config.dynamic_fps.run_garbage_collector": "GC auslösen",
+
+	"key.dynamic_fps.toggle_forced": "Unfokussierten Modus forcieren (Toggle)",
+	"key.dynamic_fps.toggle_disabled": "Dynamic FPS deaktivieren (Toggle)",
+	"gui.dynamic_fps.hud.reducing": "Dynamic FPS: tiefe FPS forciert",
+	"gui.dynamic_fps.hud.disabled": "Dynamic FPS deaktiviert",
+
+	"modmenu.descriptionTranslation.dynamic_fps": "Ändert die maximale Bildrate damit Minecraft weniger Resourcen im Hintergrund braucht."
+}

--- a/src/main/resources/assets/dynamic_fps/lang/de_at.json
+++ b/src/main/resources/assets/dynamic_fps/lang/de_at.json
@@ -1,12 +1,12 @@
 {
 	"config.dynamic_fps.title": "Dynamic FPS Konfigurieren",
 
-	"config.dynamic_fps.category.hovered": "Schwebend",
+	"config.dynamic_fps.category.hovered": "Hover",
 	"config.dynamic_fps.category.unfocused": "Unfokussiert",
 	"config.dynamic_fps.category.invisible": "Unsichtbar",
 
 	"config.dynamic_fps.frame_rate_target": "Zielbildrate",
-	"config.dynamic_fps.frame_rate_target_description": "Setze die Zielbildrate auf -1 um die Bildrate nicht zu reduzieren.",
+	"config.dynamic_fps.frame_rate_target_description": "Setze die Zielbildrate auf -1, um die Bildrate nicht zu reduzieren.",
 	"config.dynamic_fps.volume_multiplier": "Lautstärke",
 	"config.dynamic_fps.graphics_state": "Grafikoptionen",
 	"config.dynamic_fps.show_toasts": "Toasts Anzeigen",
@@ -17,5 +17,5 @@
 	"gui.dynamic_fps.hud.reducing": "Dynamic FPS: tiefe FPS forciert",
 	"gui.dynamic_fps.hud.disabled": "Dynamic FPS deaktiviert",
 
-	"modmenu.descriptionTranslation.dynamic_fps": "Ändert die maximale Bildrate damit Minecraft weniger Resourcen im Hintergrund braucht."
+	"modmenu.descriptionTranslation.dynamic_fps": "Ändert die maximale Bildrate, damit Minecraft weniger Ressourcen im Hintergrund braucht."
 }

--- a/src/main/resources/assets/dynamic_fps/lang/de_ch.json
+++ b/src/main/resources/assets/dynamic_fps/lang/de_ch.json
@@ -1,0 +1,21 @@
+{
+	"config.dynamic_fps.title": "Dynamic FPS Konfigurieren",
+
+	"config.dynamic_fps.category.hovered": "Schwebend",
+	"config.dynamic_fps.category.unfocused": "Unfokussiert",
+	"config.dynamic_fps.category.invisible": "Unsichtbar",
+
+	"config.dynamic_fps.frame_rate_target": "Zielbildrate",
+	"config.dynamic_fps.frame_rate_target_description": "Setze die Zielbildrate auf -1 um die Bildrate nicht zu reduzieren.",
+	"config.dynamic_fps.volume_multiplier": "Lautstärke",
+	"config.dynamic_fps.graphics_state": "Grafikoptionen",
+	"config.dynamic_fps.show_toasts": "Toasts Anzeigen",
+	"config.dynamic_fps.run_garbage_collector": "GC auslösen",
+
+	"key.dynamic_fps.toggle_forced": "Unfokussierten Modus forcieren (Toggle)",
+	"key.dynamic_fps.toggle_disabled": "Dynamic FPS deaktivieren (Toggle)",
+	"gui.dynamic_fps.hud.reducing": "Dynamic FPS: tiefe FPS forciert",
+	"gui.dynamic_fps.hud.disabled": "Dynamic FPS deaktiviert",
+
+	"modmenu.descriptionTranslation.dynamic_fps": "Ändert die maximale Bildrate damit Minecraft weniger Resourcen im Hintergrund braucht."
+}

--- a/src/main/resources/assets/dynamic_fps/lang/de_ch.json
+++ b/src/main/resources/assets/dynamic_fps/lang/de_ch.json
@@ -1,12 +1,12 @@
 {
 	"config.dynamic_fps.title": "Dynamic FPS Konfigurieren",
 
-	"config.dynamic_fps.category.hovered": "Schwebend",
+	"config.dynamic_fps.category.hovered": "Hover",
 	"config.dynamic_fps.category.unfocused": "Unfokussiert",
 	"config.dynamic_fps.category.invisible": "Unsichtbar",
 
 	"config.dynamic_fps.frame_rate_target": "Zielbildrate",
-	"config.dynamic_fps.frame_rate_target_description": "Setze die Zielbildrate auf -1 um die Bildrate nicht zu reduzieren.",
+	"config.dynamic_fps.frame_rate_target_description": "Setze die Zielbildrate auf -1, um die Bildrate nicht zu reduzieren.",
 	"config.dynamic_fps.volume_multiplier": "Lautstärke",
 	"config.dynamic_fps.graphics_state": "Grafikoptionen",
 	"config.dynamic_fps.show_toasts": "Toasts Anzeigen",
@@ -17,5 +17,5 @@
 	"gui.dynamic_fps.hud.reducing": "Dynamic FPS: tiefe FPS forciert",
 	"gui.dynamic_fps.hud.disabled": "Dynamic FPS deaktiviert",
 
-	"modmenu.descriptionTranslation.dynamic_fps": "Ändert die maximale Bildrate damit Minecraft weniger Resourcen im Hintergrund braucht."
+	"modmenu.descriptionTranslation.dynamic_fps": "Ändert die maximale Bildrate, damit Minecraft weniger Ressourcen im Hintergrund braucht."
 }

--- a/src/main/resources/assets/dynamic_fps/lang/de_de.json
+++ b/src/main/resources/assets/dynamic_fps/lang/de_de.json
@@ -1,12 +1,12 @@
 {
 	"config.dynamic_fps.title": "Dynamic FPS Konfigurieren",
 
-	"config.dynamic_fps.category.hovered": "Schwebend",
+	"config.dynamic_fps.category.hovered": "Hover",
 	"config.dynamic_fps.category.unfocused": "Unfokussiert",
 	"config.dynamic_fps.category.invisible": "Unsichtbar",
 
 	"config.dynamic_fps.frame_rate_target": "Zielbildrate",
-	"config.dynamic_fps.frame_rate_target_description": "Setze die Zielbildrate auf -1 um die Bildrate nicht zu reduzieren.",
+	"config.dynamic_fps.frame_rate_target_description": "Setze die Zielbildrate auf -1, um die Bildrate nicht zu reduzieren.",
 	"config.dynamic_fps.volume_multiplier": "Lautstärke",
 	"config.dynamic_fps.graphics_state": "Grafikoptionen",
 	"config.dynamic_fps.show_toasts": "Toasts Anzeigen",
@@ -17,5 +17,5 @@
 	"gui.dynamic_fps.hud.reducing": "Dynamic FPS: tiefe FPS forciert",
 	"gui.dynamic_fps.hud.disabled": "Dynamic FPS deaktiviert",
 
-	"modmenu.descriptionTranslation.dynamic_fps": "Ändert die maximale Bildrate damit Minecraft weniger Resourcen im Hintergrund braucht."
+	"modmenu.descriptionTranslation.dynamic_fps": "Ändert die maximale Bildrate, damit Minecraft weniger Ressourcen im Hintergrund braucht."
 }

--- a/src/main/resources/assets/dynamic_fps/lang/pt_pt.json
+++ b/src/main/resources/assets/dynamic_fps/lang/pt_pt.json
@@ -1,0 +1,8 @@
+{
+	"config.dynamic_fps.title": "Definições do Dynamic FPS",
+
+	"key.dynamic_fps.toggle_forced": "Forçar redução da taxa de quadros (alternável)",
+	"key.dynamic_fps.toggle_disabled": "Desativar o Disable Dynamic (alternável)",
+	"gui.dynamic_fps.hud.reducing": "Dynamic FPS: forçando a redução da taxa de quadros",
+	"gui.dynamic_fps.hud.disabled": "Dynamic FPS desativado"
+}

--- a/src/main/resources/assets/dynamic_fps/lang/zh_hk.json
+++ b/src/main/resources/assets/dynamic_fps/lang/zh_hk.json
@@ -1,0 +1,8 @@
+{
+    "config.dynamic_fps.title": "Dynamic FPS 設定",
+
+    "key.dynamic_fps.toggle_forced": "強制限制 FPS（切換）",
+    "key.dynamic_fps.toggle_disabled": "停用 Dynamic FPS（切換）",
+    "gui.dynamic_fps.hud.reducing": "Dynamic FPS：強制限制 FPS",
+    "gui.dynamic_fps.hud.disabled": "已禁用 Dynamic FPS"
+}


### PR DESCRIPTION
Same purpose as #120. Will also need to be done for dutch if we get such a translation.
I figure that generally having a not super-specific but working translation is better than none, they can be updated afterwards.