### PR TITLE
Add tooltips and named slider options to config screen

### DIFF
--- a/src/main/java/dynamic_fps/impl/GraphicsState.java
+++ b/src/main/java/dynamic_fps/impl/GraphicsState.java
@@ -29,7 +29,7 @@ public enum GraphicsState {
 	public static final Codec<GraphicsState> CODEC = new PrimitiveCodec<GraphicsState>() {
 		@Override
 		public <T> T write(DynamicOps<T> ops, GraphicsState value) {
-			return ops.createString(value.toString().toLowerCase(Locale.ROOT));
+			return ops.createString(value.toString());
 		}
 
 		@Override
@@ -43,4 +43,9 @@ public enum GraphicsState {
 			}
 		}
 	};
+
+	@Override
+	public String toString() {
+		return super.toString().toLowerCase(Locale.ROOT);
+	}
 }

--- a/src/main/java/dynamic_fps/impl/compat/ClothConfig.java
+++ b/src/main/java/dynamic_fps/impl/compat/ClothConfig.java
@@ -17,12 +17,12 @@ import dynamic_fps.impl.config.DynamicFPSConfig;
 
 public final class ClothConfig {
 	public static Screen genConfigScreen(Screen parent) {
-		ConfigBuilder builder = ConfigBuilder.create()
+		var builder = ConfigBuilder.create()
 			.setParentScreen(parent)
 			.setTitle(localized("config", "title"))
 			.setSavingRunnable(DynamicFPSMod.modConfig::save);
 
-		ConfigEntryBuilder entryBuilder = builder.entryBuilder();
+		var entryBuilder = builder.entryBuilder();
 
 		for (var state : PowerState.values()) {
 			if (!state.configurable) {
@@ -32,52 +32,68 @@ public final class ClothConfig {
 			var config = DynamicFPSMod.modConfig.get(state);
 			var standard = DynamicFPSConfig.getDefaultConfig(state);
 
-			builder.getOrCreateCategory(
-				localized("config", "category." + state.toString().toLowerCase()))
-				.addEntry(entryBuilder
-					.startIntSlider(
-						localized("config", "frame_rate_target"),
-						fromConfigFpsTarget(config.frameRateTarget()),
-						0, 61)
-					.setDefaultValue(fromConfigFpsTarget(standard.frameRateTarget()))
-					.setSaveConsumer(value -> config.setFrameRateTarget(toConfigFpsTarget(value)))
-					.setTextGetter(ClothConfig::fpsTargetMessage)
-					.build())
-				.addEntry(entryBuilder
-					.startIntSlider(
-						localized("config", "volume_multiplier"),
-						(int) (config.volumeMultiplier() * 100),
-						0, 100)
-					.setDefaultValue((int) (standard.volumeMultiplier() * 100))
-					.setSaveConsumer(value -> config.setVolumeMultiplier(value / 100f))
-					.setTextGetter(ClothConfig::volumeMultiplierMessage)
-					.build())
-				.addEntry(entryBuilder
-					.startEnumSelector(
-						localized("config", "graphics_state"),
-						GraphicsState.class,
-						config.graphicsState())
-					.setDefaultValue(standard.graphicsState())
-					.setSaveConsumer(config::setGraphicsState)
-					.setEnumNameProvider(ClothConfig::graphicsStateMessage)
-					.setTooltipSupplier(ClothConfig::graphicsStateTooltip)
-					.build())
-				.addEntry(entryBuilder
-					.startBooleanToggle(
-						localized("config", "show_toasts"),
-						config.showToasts())
-					.setDefaultValue(standard.showToasts())
-					.setSaveConsumer(config::setShowToasts)
-					.setTooltip(localized("config", "show_toasts_tooltip"))
-					.build())
-				.addEntry(entryBuilder
-					.startBooleanToggle(
-						localized("config", "run_garbage_collector"),
-						config.runGarbageCollector())
-					.setDefaultValue(standard.runGarbageCollector())
-					.setSaveConsumer(config::setRunGarbageCollector)
-					.setTooltip(localized("config", "run_garbage_collector_tooltip"))
-					.build());
+			var category = builder.getOrCreateCategory(
+				localized("config", "category." + state.toString().toLowerCase())
+			);
+
+			category.addEntry(
+				entryBuilder.startIntSlider(
+					localized("config", "frame_rate_target"),
+					fromConfigFpsTarget(config.frameRateTarget()),
+					0, 61
+				)
+				.setDefaultValue(fromConfigFpsTarget(standard.frameRateTarget()))
+				.setSaveConsumer(value -> config.setFrameRateTarget(toConfigFpsTarget(value)))
+				.setTextGetter(ClothConfig::fpsTargetMessage)
+				.build()
+			);
+
+			category.addEntry(
+				entryBuilder.startIntSlider(
+					localized("config", "volume_multiplier"),
+					(int) (config.volumeMultiplier() * 100),
+					0, 100
+				)
+				.setDefaultValue((int) (standard.volumeMultiplier() * 100))
+				.setSaveConsumer(value -> config.setVolumeMultiplier(value / 100f))
+				.setTextGetter(ClothConfig::volumeMultiplierMessage)
+				.build()
+			);
+
+			category.addEntry(
+				entryBuilder.startEnumSelector(
+					localized("config", "graphics_state"),
+					GraphicsState.class,
+					config.graphicsState()
+				)
+				.setDefaultValue(standard.graphicsState())
+				.setSaveConsumer(config::setGraphicsState)
+				.setEnumNameProvider(ClothConfig::graphicsStateMessage)
+				.setTooltipSupplier(ClothConfig::graphicsStateTooltip)
+				.build()
+			);
+
+			category.addEntry(
+				entryBuilder.startBooleanToggle(
+					localized("config", "show_toasts"),
+					config.showToasts()
+				)
+				.setDefaultValue(standard.showToasts())
+				.setSaveConsumer(config::setShowToasts)
+				.setTooltip(localized("config", "show_toasts_tooltip"))
+				.build()
+			);
+
+			category.addEntry(
+				entryBuilder.startBooleanToggle(
+					localized("config", "run_garbage_collector"),
+					config.runGarbageCollector()
+				)
+				.setDefaultValue(standard.runGarbageCollector())
+				.setSaveConsumer(config::setRunGarbageCollector)
+				.setTooltip(localized("config", "run_garbage_collector_tooltip"))
+				.build()
+			);
 		}
 
 		return builder.build();

--- a/src/main/java/dynamic_fps/impl/compat/ClothConfig.java
+++ b/src/main/java/dynamic_fps/impl/compat/ClothConfig.java
@@ -122,7 +122,18 @@ public final class ClothConfig {
 	}
 
 	private static Component graphicsStateMessage(Enum<GraphicsState> graphicsState) {
-		return localized("config", "graphics_state_" + graphicsState.toString());
+		String key;
+
+		if (graphicsState.equals(GraphicsState.DEFAULT)) {
+			key = "options.gamma.default";
+		} else if (graphicsState.equals(GraphicsState.MINIMAL)) {
+			key = "options.particles.minimal";
+		} else {
+			key = "options.particles.decreased";
+		}
+
+		return Component.translatable(key);
+		// return localized("config", "graphics_state_" + graphicsState.toString());
 	}
 
 	private static Optional<Component[]> graphicsStateTooltip(GraphicsState graphicsState) {

--- a/src/main/java/dynamic_fps/impl/util/Localization.java
+++ b/src/main/java/dynamic_fps/impl/util/Localization.java
@@ -2,6 +2,7 @@ package dynamic_fps.impl.util;
 
 import dynamic_fps.impl.DynamicFPSMod;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.MutableComponent;
 
 public final class Localization {
 	/** e.g. keyString("title", "config") -> "title.dynamic_fps.config") */
@@ -9,7 +10,7 @@ public final class Localization {
 		return domain + "." + DynamicFPSMod.MOD_ID + "." + path;
 	}
 
-	public static Component localized(String domain, String path, Object... args) {
+	public static MutableComponent localized(String domain, String path, Object... args) {
 		return Component.translatable(translationKey(domain, path), args);
 	}
 

--- a/src/main/resources/assets/dynamic_fps/lang/de_at.json
+++ b/src/main/resources/assets/dynamic_fps/lang/de_at.json
@@ -6,11 +6,19 @@
 	"config.dynamic_fps.category.invisible": "Unsichtbar",
 
 	"config.dynamic_fps.frame_rate_target": "Zielbildrate",
-	"config.dynamic_fps.frame_rate_target_description": "Setze die Zielbildrate auf -1, um die Bildrate nicht zu reduzieren.",
 	"config.dynamic_fps.volume_multiplier": "Lautstärke",
+
 	"config.dynamic_fps.graphics_state": "Grafikoptionen",
+	"config.dynamic_fps.graphics_state_default": "Standard",
+	"config.dynamic_fps.graphics_state_reduced": "Reduziert",
+	"config.dynamic_fps.graphics_state_minimal": "Minimal",
+	"config.dynamic_fps.graphics_state_minimal_tooltip": "Minimale Grafik bewirkt, dass die Welt neu lädt!",
+
 	"config.dynamic_fps.show_toasts": "Toasts Anzeigen",
+	"config.dynamic_fps.show_toasts_tooltip": "Toast Benachrichtigungen weiterhin anzeigen oder verzögern",
+
 	"config.dynamic_fps.run_garbage_collector": "GC auslösen",
+	"config.dynamic_fps.run_garbage_collector_tooltip": "Ungenutzen Arbeitsspeicher frei machen, wenn dieser Status aktiviert wird",
 
 	"key.dynamic_fps.toggle_forced": "Unfokussierten Modus forcieren (Toggle)",
 	"key.dynamic_fps.toggle_disabled": "Dynamic FPS deaktivieren (Toggle)",

--- a/src/main/resources/assets/dynamic_fps/lang/de_ch.json
+++ b/src/main/resources/assets/dynamic_fps/lang/de_ch.json
@@ -6,11 +6,19 @@
 	"config.dynamic_fps.category.invisible": "Unsichtbar",
 
 	"config.dynamic_fps.frame_rate_target": "Zielbildrate",
-	"config.dynamic_fps.frame_rate_target_description": "Setze die Zielbildrate auf -1, um die Bildrate nicht zu reduzieren.",
 	"config.dynamic_fps.volume_multiplier": "Lautstärke",
+
 	"config.dynamic_fps.graphics_state": "Grafikoptionen",
+	"config.dynamic_fps.graphics_state_default": "Standard",
+	"config.dynamic_fps.graphics_state_reduced": "Reduziert",
+	"config.dynamic_fps.graphics_state_minimal": "Minimal",
+	"config.dynamic_fps.graphics_state_minimal_tooltip": "Minimale Grafik bewirkt, dass die Welt neu lädt!",
+
 	"config.dynamic_fps.show_toasts": "Toasts Anzeigen",
+	"config.dynamic_fps.show_toasts_tooltip": "Toast Benachrichtigungen weiterhin anzeigen oder verzögern",
+
 	"config.dynamic_fps.run_garbage_collector": "GC auslösen",
+	"config.dynamic_fps.run_garbage_collector_tooltip": "Ungenutzen Arbeitsspeicher frei machen, wenn dieser Status aktiviert wird",
 
 	"key.dynamic_fps.toggle_forced": "Unfokussierten Modus forcieren (Toggle)",
 	"key.dynamic_fps.toggle_disabled": "Dynamic FPS deaktivieren (Toggle)",

--- a/src/main/resources/assets/dynamic_fps/lang/de_de.json
+++ b/src/main/resources/assets/dynamic_fps/lang/de_de.json
@@ -6,11 +6,19 @@
 	"config.dynamic_fps.category.invisible": "Unsichtbar",
 
 	"config.dynamic_fps.frame_rate_target": "Zielbildrate",
-	"config.dynamic_fps.frame_rate_target_description": "Setze die Zielbildrate auf -1, um die Bildrate nicht zu reduzieren.",
 	"config.dynamic_fps.volume_multiplier": "Lautstärke",
+
 	"config.dynamic_fps.graphics_state": "Grafikoptionen",
+	"config.dynamic_fps.graphics_state_default": "Standard",
+	"config.dynamic_fps.graphics_state_reduced": "Reduziert",
+	"config.dynamic_fps.graphics_state_minimal": "Minimal",
+	"config.dynamic_fps.graphics_state_minimal_tooltip": "Minimale Grafik bewirkt, dass die Welt neu lädt!",
+
 	"config.dynamic_fps.show_toasts": "Toasts Anzeigen",
+	"config.dynamic_fps.show_toasts_tooltip": "Toast Benachrichtigungen weiterhin anzeigen oder verzögern",
+
 	"config.dynamic_fps.run_garbage_collector": "GC auslösen",
+	"config.dynamic_fps.run_garbage_collector_tooltip": "Ungenutzen Arbeitsspeicher frei machen, wenn dieser Status aktiviert wird",
 
 	"key.dynamic_fps.toggle_forced": "Unfokussierten Modus forcieren (Toggle)",
 	"key.dynamic_fps.toggle_disabled": "Dynamic FPS deaktivieren (Toggle)",

--- a/src/main/resources/assets/dynamic_fps/lang/en_us.json
+++ b/src/main/resources/assets/dynamic_fps/lang/en_us.json
@@ -6,11 +6,19 @@
 	"config.dynamic_fps.category.invisible": "Invisible",
 
 	"config.dynamic_fps.frame_rate_target": "Frame Rate Target",
-	"config.dynamic_fps.frame_rate_target_description": "Set Frame Rate Target to -1 to disable reducing FPS.",
 	"config.dynamic_fps.volume_multiplier": "Volume Multiplier",
+
 	"config.dynamic_fps.graphics_state": "Graphics Options",
+	"config.dynamic_fps.graphics_state_default": "Default",
+	"config.dynamic_fps.graphics_state_reduced": "Reduced",
+	"config.dynamic_fps.graphics_state_minimal": "Minimal",
+	"config.dynamic_fps.graphics_state_minimal_tooltip": "Minimal graphics cause the world to reload!",
+
 	"config.dynamic_fps.show_toasts": "Show Toasts",
+	"config.dynamic_fps.show_toasts_tooltip": "Whether to keep displaying or delay toast notifications",
+
 	"config.dynamic_fps.run_garbage_collector": "Invoke Garbage Collector",
+	"config.dynamic_fps.run_garbage_collector_tooltip": "Free up unused memory when switching to this status",
 
 	"key.dynamic_fps.toggle_forced": "Force Unfocused Mode (Toggle)",
 	"key.dynamic_fps.toggle_disabled": "Disable Dynamic FPS (Toggle)",


### PR DESCRIPTION
Fixes up some config screen stuff I missed previously because I did not realize it's possible :)

- Volume multiplier and graphics options values use proper labels / are now translatable
- Tooltips as warning for minimal graphics state, and to explain what the toast and gc options do
- The frame rate target slider now has an "Unlimited" option on the right instead of the magic -1 value

![Screenshot of the config screen with these changes applied](https://files.lostluma.net/Y0hBmr.png)