### PR TITLE
Always run state change checks and tasks on main thread

### DIFF
--- a/src/main/java/dynamic_fps/impl/DynamicFPSMod.java
+++ b/src/main/java/dynamic_fps/impl/DynamicFPSMod.java
@@ -176,6 +176,15 @@ public class DynamicFPSMod implements ClientModInitializer {
 			minecraft = Minecraft.getInstance();
 		}
 
+		if (minecraft.isSameThread()) {
+			checkForStateChanges0();
+		} else {
+			// Schedule check for the beginning of the next frame
+			minecraft.tell(DynamicFPSMod::checkForStateChanges0);
+		}
+	}
+
+	private static void checkForStateChanges0() {
 		PowerState current;
 
 		if (isDisabledInternal()) {


### PR DESCRIPTION
Flawless Frames producers can (as far as I'm aware) call the entrypoint from any thread.  
I don't think this has caused any issues in the past, but I'd like this implementation to be correct just in case.