### PR TITLE
Atomic config saving

### DIFF
--- a/src/main/java/dynamic_fps/impl/DynamicFPSMod.java
+++ b/src/main/java/dynamic_fps/impl/DynamicFPSMod.java
@@ -62,8 +62,6 @@ public class DynamicFPSMod implements ClientModInitializer {
 
 	@Override
 	public void onInitializeClient() {
-		modConfig.save(); // Force create file on disk
-
 		toggleForcedKeyBinding.register();
 		toggleDisabledKeyBinding.register();
 

--- a/src/main/java/dynamic_fps/impl/config/DynamicFPSConfig.java
+++ b/src/main/java/dynamic_fps/impl/config/DynamicFPSConfig.java
@@ -56,7 +56,9 @@ public final class DynamicFPSConfig {
 		try {
 			data = Files.readString(PATH);
 		} catch (NoSuchFileException e) {
-			return new DynamicFPSConfig(new EnumMap<>(PowerState.class));
+			var config = new DynamicFPSConfig(new EnumMap<>(PowerState.class));
+			config.save();
+			return config;
 		} catch (IOException e) {
 			throw new RuntimeException("Failed to load Dynamic FPS config.", e);
 		}

--- a/src/main/java/dynamic_fps/impl/config/DynamicFPSConfig.java
+++ b/src/main/java/dynamic_fps/impl/config/DynamicFPSConfig.java
@@ -5,6 +5,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.EnumMap;
 import java.util.Map;
 
@@ -21,7 +22,9 @@ import net.fabricmc.loader.api.FabricLoader;
 public final class DynamicFPSConfig {
 	private Map<PowerState, Config> configs;
 
-	private static final Path PATH = FabricLoader.getInstance().getConfigDir().resolve(DynamicFPSMod.MOD_ID + ".json");
+	private static final Path CONFIGS = FabricLoader.getInstance().getConfigDir();
+	private static final Path CONFIG_FILE = CONFIGS.resolve(DynamicFPSMod.MOD_ID + ".json");
+
 	private static final Codec<Map<PowerState, Config>> STATES_CODEC = Codec.unboundedMap(PowerState.CODEC, Config.CODEC);
 
 	private static final Codec<DynamicFPSConfig> CODEC = RecordCodecBuilder.create(instance -> instance.group(
@@ -54,7 +57,7 @@ public final class DynamicFPSConfig {
 		String data;
 
 		try {
-			data = Files.readString(PATH);
+			data = Files.readString(CONFIG_FILE);
 		} catch (NoSuchFileException e) {
 			var config = new DynamicFPSConfig(new EnumMap<>(PowerState.class));
 			config.save();
@@ -74,10 +77,14 @@ public final class DynamicFPSConfig {
 		var root = data.getOrThrow(false, RuntimeException::new);
 
 		try {
-			Files.writeString(PATH, root.toString(), StandardCharsets.UTF_8);
+			var temp = Files.createTempFile(CONFIGS, "dynamic_fps", ".json");
+			Files.writeString(temp, root.toString(), StandardCharsets.UTF_8);
+
+			Files.deleteIfExists(CONFIG_FILE);
+			Files.move(temp, CONFIG_FILE, StandardCopyOption.ATOMIC_MOVE);
 		} catch (IOException e) {
-			// Cloth Config's automatic saving does not support catching exceptions
-			throw new RuntimeException("Failed to save Dynamic FPS config.", e);
+			// Cloth Config's built-in saving does not support catching exceptions :(
+			throw new RuntimeException("Failed to save or modify Dynamic FPS config!", e);
 		}
 	}
 


### PR DESCRIPTION
Saves the config file atomically to prevent corruption, fixing issues such as #138.
Additionally the config is no longer written to disk every launch, but only on first launch and when modified.