### PR TITLE
Add idle detection and mode

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,10 @@ dependencies {
 	modApi libs.cloth.config
 }
 
+loom {
+	accessWidenerPath = file("src/main/resources/dynamic_fps.accesswidener")
+}
+
 processResources {
 	inputs.property "version", generateVersion()
 

--- a/src/main/java/dynamic_fps/impl/PowerState.java
+++ b/src/main/java/dynamic_fps/impl/PowerState.java
@@ -6,22 +6,27 @@ package dynamic_fps.impl;
  * Power states are prioritized based on their order here, see DynamicFPSMod.checkForStateChanges for impl details.
  */
 public enum PowerState {
-	/*
+	/**
 	 * Window is currently focused.
 	 */
 	FOCUSED(false),
 
-	/*
+	/**
 	 * Mouse positioned over unfocused window.
 	 */
 	HOVERED(true),
 
-	/*
+	/**
 	 * Another application is focused.
 	 */
 	UNFOCUSED(true),
 
-	/*
+	/**
+	 * User hasn't sent input for some time.
+	 */
+	ABANDONED(true),
+
+	/**
 	 * Window minimized or otherwise hidden.
 	 */
 	INVISIBLE(true);

--- a/src/main/java/dynamic_fps/impl/compat/ClothConfig.java
+++ b/src/main/java/dynamic_fps/impl/compat/ClothConfig.java
@@ -20,9 +20,26 @@ public final class ClothConfig {
 		var builder = ConfigBuilder.create()
 			.setParentScreen(parent)
 			.setTitle(localized("config", "title"))
-			.setSavingRunnable(DynamicFPSMod.modConfig::save);
+			.setSavingRunnable(DynamicFPSMod::onConfigChanged);
 
 		var entryBuilder = builder.entryBuilder();
+
+		var general = builder.getOrCreateCategory(
+			localized("config", "category.general")
+		);
+
+		general.addEntry(
+			entryBuilder.startIntSlider(
+				localized("config", "idle_time"),
+				DynamicFPSMod.modConfig.idleTime() / 60,
+				0, 30
+			)
+			.setDefaultValue(0)
+			.setSaveConsumer(value -> DynamicFPSMod.modConfig.setIdleTime(value * 60))
+			.setTextGetter(ClothConfig::idleTimeMessage)
+			.setTooltip(localized("config", "idle_time_tooltip"))
+			.build()
+		);
 
 		for (var state : PowerState.values()) {
 			if (!state.configurable) {
@@ -105,6 +122,14 @@ public final class ClothConfig {
 		}
 
 		return builder.build();
+	}
+
+	private static Component idleTimeMessage(int value) {
+		if (value == 0) {
+			return localized("config", "disabled");
+		} else {
+			return localized("config", "minutes", value);
+		}
 	}
 
 	// Convert magic -1 number to 61 (and reverse)

--- a/src/main/java/dynamic_fps/impl/mixin/MinecraftMixin.java
+++ b/src/main/java/dynamic_fps/impl/mixin/MinecraftMixin.java
@@ -1,15 +1,28 @@
 package dynamic_fps.impl.mixin;
 
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import com.mojang.blaze3d.platform.Window;
 
 import dynamic_fps.impl.DynamicFPSMod;
 import net.minecraft.client.Minecraft;
 
 @Mixin(Minecraft.class)
 public class MinecraftMixin {
+	@Shadow
+	@Final
+    private Window window;
+
+	@Inject(method = "<init>", at = @At("TAIL"))
+	private void onInit(CallbackInfo callbackInfo) {
+		DynamicFPSMod.setWindow(this.window.window);
+	}
+
 	@Inject(method = "setScreen", at = @At("TAIL"))
 	private void onSetScreen(CallbackInfo callbackInfo) {
 		DynamicFPSMod.onStatusChanged();

--- a/src/main/java/dynamic_fps/impl/mixin/WindowMixin.java
+++ b/src/main/java/dynamic_fps/impl/mixin/WindowMixin.java
@@ -1,11 +1,8 @@
 package dynamic_fps.impl.mixin;
 
-import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import com.mojang.blaze3d.platform.Window;
@@ -14,15 +11,6 @@ import dynamic_fps.impl.DynamicFPSMod;
 
 @Mixin(Window.class)
 public class WindowMixin {
-	@Shadow
-	@Final
-	private long window;
-
-	@Inject(method = "<init>", at = @At("TAIL"))
-	private void postinit(CallbackInfo callbackInfo) {
-		DynamicFPSMod.setWindow(this.window);
-	}
-
 	/**
 	 * Sets a frame rate limit while we're cancelling some or all rendering.
 	 */

--- a/src/main/java/dynamic_fps/impl/util/event/InputObserver.java
+++ b/src/main/java/dynamic_fps/impl/util/event/InputObserver.java
@@ -1,0 +1,99 @@
+package dynamic_fps.impl.util.event;
+
+import org.lwjgl.glfw.GLFW;
+import org.lwjgl.glfw.GLFWCharModsCallback;
+import org.lwjgl.glfw.GLFWCursorPosCallback;
+import org.lwjgl.glfw.GLFWDropCallback;
+import org.lwjgl.glfw.GLFWKeyCallback;
+import org.lwjgl.glfw.GLFWMouseButtonCallback;
+import org.lwjgl.glfw.GLFWScrollCallback;
+
+import net.minecraft.Util;
+
+public class InputObserver {
+	private final long window;
+
+	private long lastAction = Util.getEpochMillis();
+
+	// Keyboard
+	private final GLFWKeyCallback previousKeyCallback;
+	private final GLFWCharModsCallback previousCharModsCallback;
+
+	// Mouse / Trackpad etc.
+	private final GLFWDropCallback previousDropCallback;
+	private final GLFWScrollCallback previousScrollCallback;
+	private final GLFWCursorPosCallback previousCursorPosCallback;
+	private final GLFWMouseButtonCallback previousMouseClickCallback;
+
+	public InputObserver(long address) {
+		this.window = address;
+
+		this.previousKeyCallback = GLFW.glfwSetKeyCallback(this.window, this::onKey);
+		this.previousCharModsCallback = GLFW.glfwSetCharModsCallback(this.window, this::onCharMods);
+
+		this.previousDropCallback = GLFW.glfwSetDropCallback(this.window, this::onDrop);
+		this.previousScrollCallback = GLFW.glfwSetScrollCallback(this.window, this::onScroll);
+		this.previousCursorPosCallback = GLFW.glfwSetCursorPosCallback(this.window, this::onMove);
+		this.previousMouseClickCallback = GLFW.glfwSetMouseButtonCallback(this.window, this::onPress);
+	}
+
+	public long lastActionTime() {
+		return this.lastAction;
+	}
+
+	private void updateTime() {
+		this.lastAction = Util.getEpochMillis();
+	}
+
+	// Keyboard events
+
+	private void onKey(long address, int key, int scancode, int action, int mods) {
+		this.updateTime();
+
+		if (this.previousKeyCallback != null) {
+			this.previousKeyCallback.invoke(address, key, scancode, action, mods);
+		}
+	}
+
+	private void onCharMods(long address, int codepoint, int mods) {
+		this.updateTime();
+
+		if (this.previousCharModsCallback != null) {
+			this.previousCharModsCallback.invoke(address, codepoint, mods);
+		}
+	}
+
+	// Mouse events
+
+	private void onDrop(long address, int count, long names) {
+		this.updateTime();
+
+		if (this.previousDropCallback != null) {
+			this.previousDropCallback.invoke(address, count, names);
+		}
+	}
+
+	private void onScroll(long address, double xoffset, double yoffset) {
+		this.updateTime();
+
+		if (this.previousScrollCallback != null) {
+			this.previousScrollCallback.invoke(address, xoffset, yoffset);
+		}
+	}
+
+	private void onMove(long address, double x, double y) {
+		this.updateTime();
+
+		if (this.previousCursorPosCallback != null) {
+			this.previousCursorPosCallback.invoke(address, x, y);
+		}
+	}
+
+	private void onPress(long address, int button, int action, int mods) {
+		this.updateTime();
+
+		if (this.previousMouseClickCallback != null) {
+			this.previousMouseClickCallback.invoke(address, button, action, mods);
+		}
+	}
+}

--- a/src/main/java/dynamic_fps/impl/util/event/WindowObserver.java
+++ b/src/main/java/dynamic_fps/impl/util/event/WindowObserver.java
@@ -1,4 +1,4 @@
-package dynamic_fps.impl.util;
+package dynamic_fps.impl.util.event;
 
 import org.lwjgl.glfw.GLFW;
 import org.lwjgl.glfw.GLFWCursorEnterCallback;
@@ -22,11 +22,11 @@ public class WindowObserver {
 	public WindowObserver(long address) {
 		this.window = address;
 
-		previousFocusCallback = GLFW.glfwSetWindowFocusCallback(this.window, this::onFocusChanged);
-		previousMouseCallback = GLFW.glfwSetCursorEnterCallback(this.window, this::onMouseChanged);
+		this.previousFocusCallback = GLFW.glfwSetWindowFocusCallback(this.window, this::onFocusChanged);
+		this.previousMouseCallback = GLFW.glfwSetCursorEnterCallback(this.window, this::onMouseChanged);
 
 		// Vanilla doesn't use this (currently), other mods might register this callback though ...
-		previousIconifyCallback = GLFW.glfwSetWindowIconifyCallback(this.window, this::onIconifyChanged);
+		this.previousIconifyCallback = GLFW.glfwSetWindowIconifyCallback(this.window, this::onIconifyChanged);
 	}
 
 	private boolean isCurrentWindow(long address) {
@@ -43,8 +43,8 @@ public class WindowObserver {
 			DynamicFPSMod.onStatusChanged();
 		}
 
-		if (previousFocusCallback != null) {
-			previousFocusCallback.invoke(address, focused);
+		if (this.previousFocusCallback != null) {
+			this.previousFocusCallback.invoke(address, focused);
 		}
 	}
 
@@ -58,8 +58,8 @@ public class WindowObserver {
 			DynamicFPSMod.onStatusChanged();
 		}
 
-		if (previousMouseCallback != null) {
-			previousMouseCallback.invoke(address, hovered);
+		if (this.previousMouseCallback != null) {
+			this.previousMouseCallback.invoke(address, hovered);
 		}
 	}
 
@@ -73,8 +73,8 @@ public class WindowObserver {
 			DynamicFPSMod.onStatusChanged();
 		}
 
-		if (previousIconifyCallback != null) {
-			previousIconifyCallback.invoke(address, iconified);
+		if (this.previousIconifyCallback != null) {
+			this.previousIconifyCallback.invoke(address, iconified);
 		}
 	}
 }

--- a/src/main/resources/assets/dynamic_fps/lang/de_at.json
+++ b/src/main/resources/assets/dynamic_fps/lang/de_at.json
@@ -1,8 +1,10 @@
 {
 	"config.dynamic_fps.title": "Dynamic FPS Konfigurieren",
 
+	"config.dynamic_fps.category.general": "Allgemein",
 	"config.dynamic_fps.category.hovered": "Hover",
 	"config.dynamic_fps.category.unfocused": "Unfokussiert",
+	"config.dynamic_fps.category.abandoned": "Untätig",
 	"config.dynamic_fps.category.invisible": "Unsichtbar",
 
 	"config.dynamic_fps.frame_rate_target": "Zielbildrate",

--- a/src/main/resources/assets/dynamic_fps/lang/de_ch.json
+++ b/src/main/resources/assets/dynamic_fps/lang/de_ch.json
@@ -1,8 +1,10 @@
 {
 	"config.dynamic_fps.title": "Dynamic FPS Konfigurieren",
 
+	"config.dynamic_fps.category.general": "Allgemein",
 	"config.dynamic_fps.category.hovered": "Hover",
 	"config.dynamic_fps.category.unfocused": "Unfokussiert",
+	"config.dynamic_fps.category.abandoned": "Untätig",
 	"config.dynamic_fps.category.invisible": "Unsichtbar",
 
 	"config.dynamic_fps.frame_rate_target": "Zielbildrate",

--- a/src/main/resources/assets/dynamic_fps/lang/de_de.json
+++ b/src/main/resources/assets/dynamic_fps/lang/de_de.json
@@ -1,8 +1,10 @@
 {
 	"config.dynamic_fps.title": "Dynamic FPS Konfigurieren",
 
+	"config.dynamic_fps.category.general": "Allgemein",
 	"config.dynamic_fps.category.hovered": "Hover",
 	"config.dynamic_fps.category.unfocused": "Unfokussiert",
+	"config.dynamic_fps.category.abandoned": "Untätig",
 	"config.dynamic_fps.category.invisible": "Unsichtbar",
 
 	"config.dynamic_fps.frame_rate_target": "Zielbildrate",

--- a/src/main/resources/assets/dynamic_fps/lang/en_us.json
+++ b/src/main/resources/assets/dynamic_fps/lang/en_us.json
@@ -1,9 +1,17 @@
 {
 	"config.dynamic_fps.title": "Configure Dynamic FPS",
 
+	"config.dynamic_fps.category.general": "General",
 	"config.dynamic_fps.category.hovered": "Hovered",
 	"config.dynamic_fps.category.unfocused": "Unfocused",
+	"config.dynamic_fps.category.abandoned": "Idle",
 	"config.dynamic_fps.category.invisible": "Invisible",
+
+	"config.dynamic_fps.disabled": "Disabled",
+	"config.dynamic_fps.minutes": "%d Minute(s)",
+
+	"config.dynamic_fps.idle_time": "Idle time",
+	"config.dynamic_fps.idle_time_tooltip": "Minutes without input until Dynamic FPS activates the Idle state while the game is focused.",
 
 	"config.dynamic_fps.frame_rate_target": "Frame Rate Target",
 	"config.dynamic_fps.volume_multiplier": "Volume Multiplier",

--- a/src/main/resources/assets/dynamic_fps/lang/et_ee.json
+++ b/src/main/resources/assets/dynamic_fps/lang/et_ee.json
@@ -1,6 +1,8 @@
 {
 	"config.dynamic_fps.title": "Dynamic FPS seadistus",
 
+	"config.dynamic_fps.category.general": "Üldine",
+
 	"key.dynamic_fps.toggle_forced": "Sunni vähendatud ks (lüliti)",
 	"key.dynamic_fps.toggle_disabled": "Keela Dynamic FPS (lüliti)",
 	"gui.dynamic_fps.hud.reducing": "Dynamic FPS: sunnin vähendatud kaadrisagedust",

--- a/src/main/resources/assets/dynamic_fps/lang/fr_ca.json
+++ b/src/main/resources/assets/dynamic_fps/lang/fr_ca.json
@@ -1,6 +1,7 @@
 {
 	"config.dynamic_fps.title": "Configuration de Dynamic FPS",
 
+	"config.dynamic_fps.category.general": "Général",
 	"config.dynamic_fps.category.hovered": "Survolé",
 	"config.dynamic_fps.category.unfocused": "Non-focalisé",
 	"config.dynamic_fps.category.invisible": "Invisible",

--- a/src/main/resources/assets/dynamic_fps/lang/fr_fr.json
+++ b/src/main/resources/assets/dynamic_fps/lang/fr_fr.json
@@ -1,6 +1,7 @@
 {
 	"config.dynamic_fps.title": "Configuration de Dynamic FPS",
 
+	"config.dynamic_fps.category.general": "Général",
 	"config.dynamic_fps.category.hovered": "Survolé",
 	"config.dynamic_fps.category.unfocused": "Non-focalisé",
 	"config.dynamic_fps.category.invisible": "Invisible",

--- a/src/main/resources/assets/dynamic_fps/lang/it_it.json
+++ b/src/main/resources/assets/dynamic_fps/lang/it_it.json
@@ -1,6 +1,7 @@
 {
 	"config.dynamic_fps.title": "Configura Dynamic FPS",
 
+	"config.dynamic_fps.category.general": "Generale",
 	"config.dynamic_fps.category.hovered": "Sopra il cursore",
 	"config.dynamic_fps.category.unfocused": "Non in primo piano",
 	"config.dynamic_fps.category.invisible": "Invisibile",

--- a/src/main/resources/assets/dynamic_fps/lang/ko_kr.json
+++ b/src/main/resources/assets/dynamic_fps/lang/ko_kr.json
@@ -1,6 +1,8 @@
 {
 	"config.dynamic_fps.title": "Dynamic FPS 구성",
 
+	"config.dynamic_fps.category.general": "일반",
+
 	"key.dynamic_fps.toggle_forced": "강제로 FPS 감소 (토글)",
 	"key.dynamic_fps.toggle_disabled": "Dynamic FPS 비활성화 (Toggle)",
 	"gui.dynamic_fps.hud.reducing": "Dynamic FPS: 강제로 FPS 감소중",

--- a/src/main/resources/assets/dynamic_fps/lang/pl_pl.json
+++ b/src/main/resources/assets/dynamic_fps/lang/pl_pl.json
@@ -1,6 +1,8 @@
 {
 	"config.dynamic_fps.title": "Skonfiguruj Dynamic FPS",
 
+	"config.dynamic_fps.category.general": "Ogólne",
+
 	"key.dynamic_fps.toggle_forced": "Wymuś obniżenie FPS (przełącznik)",
 	"key.dynamic_fps.toggle_disabled": "Wyłącz Dynamic FPS (przełącznik)",
 	"gui.dynamic_fps.hud.reducing": "Dynamic FPS: wymuszono obniżenie FPS",

--- a/src/main/resources/assets/dynamic_fps/lang/pt_br.json
+++ b/src/main/resources/assets/dynamic_fps/lang/pt_br.json
@@ -1,6 +1,8 @@
 {
 	"config.dynamic_fps.title": "Definições do Dynamic FPS",
 
+	"config.dynamic_fps.category.general": "Geral",
+
 	"key.dynamic_fps.toggle_forced": "Forçar redução da taxa de quadros (alternável)",
 	"key.dynamic_fps.toggle_disabled": "Desativar o Disable Dynamic (alternável)",
 	"gui.dynamic_fps.hud.reducing": "Dynamic FPS: forçando a redução da taxa de quadros",

--- a/src/main/resources/assets/dynamic_fps/lang/pt_pt.json
+++ b/src/main/resources/assets/dynamic_fps/lang/pt_pt.json
@@ -1,6 +1,8 @@
 {
 	"config.dynamic_fps.title": "Definições do Dynamic FPS",
 
+	"config.dynamic_fps.category.general": "Geral",
+
 	"key.dynamic_fps.toggle_forced": "Forçar redução da taxa de quadros (alternável)",
 	"key.dynamic_fps.toggle_disabled": "Desativar o Disable Dynamic (alternável)",
 	"gui.dynamic_fps.hud.reducing": "Dynamic FPS: forçando a redução da taxa de quadros",

--- a/src/main/resources/assets/dynamic_fps/lang/ru_ru.json
+++ b/src/main/resources/assets/dynamic_fps/lang/ru_ru.json
@@ -1,6 +1,7 @@
 {
 	"config.dynamic_fps.title": "Настройки Dynamic FPS",
 
+	"config.dynamic_fps.category.general": "Основные",
 	"config.dynamic_fps.category.hovered": "Наведён",
 	"config.dynamic_fps.category.unfocused": "Расфокусирован",
 	"config.dynamic_fps.category.invisible": "Свёрнут",

--- a/src/main/resources/assets/dynamic_fps/lang/sv_se.json
+++ b/src/main/resources/assets/dynamic_fps/lang/sv_se.json
@@ -1,9 +1,10 @@
 {
 	"config.dynamic_fps.title": "Konfigurera Dynamic FPS",
 
+	"config.dynamic_fps.category.general": "Allmänt",
 	"config.dynamic_fps.category.hovered": "Hovrande",
 	"config.dynamic_fps.category.unfocused": "Ofokuserad",
-	"config.dynamic_fps.category.invisible": "Osynlig",	
+	"config.dynamic_fps.category.invisible": "Osynlig",
 
 	"config.dynamic_fps.frame_rate_target": "Bildfrekvensmål",
 	"config.dynamic_fps.frame_rate_target_description": "Ställ in bildfrekvensmålet till -1 för att stänga av bildfrekvens reducering.",
@@ -11,7 +12,7 @@
 	"config.dynamic_fps.graphics_state": "Bildskärmsinställningar",
 	"config.dynamic_fps.show_toasts": "Visa Toasts",
 	"config.dynamic_fps.run_garbage_collector": "Starta GC",
-	
+
 	"key.dynamic_fps.toggle_forced": "Tvinga Reducerad FPS (Växla)",
 	"key.dynamic_fps.toggle_disabled": "Inaktivera Dynamic FPS (Växla)",
 	"gui.dynamic_fps.hud.reducing": "Dynamic FPS: Tvingar Reducerad BPS",

--- a/src/main/resources/assets/dynamic_fps/lang/tr_tr.json
+++ b/src/main/resources/assets/dynamic_fps/lang/tr_tr.json
@@ -1,6 +1,8 @@
 {
 	"config.dynamic_fps.title": "Dinamik FPS Ayarları",
 
+	"config.dynamic_fps.category.general": "Genel",
+
 	"key.dynamic_fps.toggle_forced": "Zorla Azaltılmış FPS (Aç / kapat)",
 	"key.dynamic_fps.toggle_disabled": "Dinamik FPS'yi Devre Dışı Bırak (Aç / kapat)",
 	"gui.dynamic_fps.hud.reducing": "Dinamik FPS: Azaltılmış FPS Zorlanıyor",

--- a/src/main/resources/assets/dynamic_fps/lang/uk_ua.json
+++ b/src/main/resources/assets/dynamic_fps/lang/uk_ua.json
@@ -1,6 +1,8 @@
 {
 	"config.dynamic_fps.title": "Параметри Dynamic FPS",
 
+	"config.dynamic_fps.category.general": "Загальні",
+
 	"key.dynamic_fps.toggle_forced": "Примусово знижувати частоту кадрів (перемикання)",
 	"key.dynamic_fps.toggle_disabled": "Вимкнути Dynamic FPS (перемикання)",
 	"gui.dynamic_fps.hud.reducing": "Dynamic FPS: Увімкнено примусове зниження частоти кадрів",

--- a/src/main/resources/assets/dynamic_fps/lang/vi_vn.json
+++ b/src/main/resources/assets/dynamic_fps/lang/vi_vn.json
@@ -1,6 +1,8 @@
 {
 	"config.dynamic_fps.title": "Định cấu hình Dynamic FPS",
 
+	"config.dynamic_fps.category.general": "Chung",
+
 	"key.dynamic_fps.toggle_forced": "Buộc giảm FPS (Đổi)",
 	"key.dynamic_fps.toggle_disabled": "Vô hiệu hoá Dynamic FPS (Đổi)",
 	"gui.dynamic_fps.hud.reducing": "Dynamic FPS: Buộc giảm FPS",

--- a/src/main/resources/assets/dynamic_fps/lang/zh_cn.json
+++ b/src/main/resources/assets/dynamic_fps/lang/zh_cn.json
@@ -1,6 +1,7 @@
 {
 	"config.dynamic_fps.title": "Dynamic FPS 动态帧率配置",
 
+	"config.dynamic_fps.category.general": "预设",
 	"config.dynamic_fps.category.hovered": "悬停",
 	"config.dynamic_fps.category.unfocused": "失焦",
 	"config.dynamic_fps.category.invisible": "不可见",

--- a/src/main/resources/assets/dynamic_fps/lang/zh_tw.json
+++ b/src/main/resources/assets/dynamic_fps/lang/zh_tw.json
@@ -1,6 +1,7 @@
 {
 	"config.dynamic_fps.title": "設定 Dynamic FPS",
 
+	"config.dynamic_fps.category.general": "一般",
 	"config.dynamic_fps.category.hovered": "聚焦時",
 	"config.dynamic_fps.category.unfocused": "未聚焦時",
 	"config.dynamic_fps.category.invisible": "不可見時",

--- a/src/main/resources/dynamic_fps.accesswidener
+++ b/src/main/resources/dynamic_fps.accesswidener
@@ -1,0 +1,3 @@
+accessWidener v2 named
+
+accessible field com/mojang/blaze3d/platform/Window window J

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -31,6 +31,7 @@
 	"mixins": [
 		"dynamic_fps.mixins.json"
 	],
+	"accessWidener": "dynamic_fps.accesswidener",
 
 	"depends": {
 		"minecraft": ">=1.20.0",


### PR DESCRIPTION
Resolves #92.

Users can choose to activate an optional `Idle` power state when the window is focused but no input has been sent for an amount of 1 to 30 minutes.

Since this incurs a small runtime cost this functionality is only active for users choosing to use it, and it only runs 20 times per second instead of e.g. every frame.