### PR TITLE
Fix idle checks always being registered

### DIFF
--- a/src/main/java/dynamic_fps/impl/DynamicFPSMod.java
+++ b/src/main/java/dynamic_fps/impl/DynamicFPSMod.java
@@ -161,7 +161,7 @@ public class DynamicFPSMod implements ClientModInitializer {
 			return;
 		}
 
-		if (modConfig.idleTime() == -1) {
+		if (modConfig.idleTime() == 0) {
 			return;
 		}
 

--- a/src/main/java/dynamic_fps/impl/util/event/WindowObserver.java
+++ b/src/main/java/dynamic_fps/impl/util/event/WindowObserver.java
@@ -8,7 +8,7 @@ import org.lwjgl.glfw.GLFWWindowIconifyCallback;
 import dynamic_fps.impl.DynamicFPSMod;
 
 public class WindowObserver {
-	private final long window;
+	private final long address;
 
 	private boolean isFocused = true;
 	private final GLFWWindowFocusCallback previousFocusCallback;
@@ -20,17 +20,21 @@ public class WindowObserver {
 	private final GLFWWindowIconifyCallback previousIconifyCallback;
 
 	public WindowObserver(long address) {
-		this.window = address;
+		this.address = address;
 
-		this.previousFocusCallback = GLFW.glfwSetWindowFocusCallback(this.window, this::onFocusChanged);
-		this.previousMouseCallback = GLFW.glfwSetCursorEnterCallback(this.window, this::onMouseChanged);
+		this.previousFocusCallback = GLFW.glfwSetWindowFocusCallback(this.address, this::onFocusChanged);
+		this.previousMouseCallback = GLFW.glfwSetCursorEnterCallback(this.address, this::onMouseChanged);
 
 		// Vanilla doesn't use this (currently), other mods might register this callback though ...
-		this.previousIconifyCallback = GLFW.glfwSetWindowIconifyCallback(this.window, this::onIconifyChanged);
+		this.previousIconifyCallback = GLFW.glfwSetWindowIconifyCallback(this.address, this::onIconifyChanged);
 	}
 
 	private boolean isCurrentWindow(long address) {
-		return address == this.window;
+		return address == this.address;
+	}
+
+	public long address() {
+		return this.address;
 	}
 
 	public boolean isFocused() {


### PR DESCRIPTION
Fixes the idle checks erroneously always being registered, even when unused.
Also only tracks the last keyboard / mouse input time when the idle checker is enabled.

This doesn't really cause any problems but if we can run less code for users not using a feature we might as well.