### PR TITLE
Add option to disable the menu FPS limit

### DIFF
--- a/src/main/java/dynamic_fps/impl/DynamicFPSMod.java
+++ b/src/main/java/dynamic_fps/impl/DynamicFPSMod.java
@@ -130,6 +130,10 @@ public class DynamicFPSMod implements ClientModInitializer {
 		return config.frameRateTarget();
 	}
 
+	public static boolean uncapMenuFrameRate() {
+		return modConfig.uncapMenuFrameRate();
+	}
+
 	public static float volumeMultiplier(SoundSource source) {
 		return config.volumeMultiplier(source);
 	}

--- a/src/main/java/dynamic_fps/impl/compat/ClothConfig.java
+++ b/src/main/java/dynamic_fps/impl/compat/ClothConfig.java
@@ -46,6 +46,17 @@ public final class ClothConfig {
 			.build()
 		);
 
+		general.addEntry(
+			entryBuilder.startBooleanToggle(
+				localized("config", "uncap_menu_frame_rate"),
+				DynamicFPSMod.modConfig.uncapMenuFrameRate()
+			)
+			.setDefaultValue(false)
+			.setSaveConsumer(DynamicFPSMod.modConfig::setUncapMenuFrameRate)
+			.setTooltip(localized("config", "uncap_menu_frame_rate_tooltip"))
+			.build()
+		);
+
 		for (PowerState state : PowerState.values()) {
 			if (!state.configurable) {
 				continue;

--- a/src/main/java/dynamic_fps/impl/config/DynamicFPSConfig.java
+++ b/src/main/java/dynamic_fps/impl/config/DynamicFPSConfig.java
@@ -8,11 +8,15 @@ import dynamic_fps.impl.PowerState;
 
 public final class DynamicFPSConfig {
 	private int idleTime; // Seconds
+	private boolean uncapMenuFrameRate;
+
 	@SerializedName("states")
 	private final Map<PowerState, Config> configs;
 
-	DynamicFPSConfig(int abandonTime, Map<PowerState, Config> configs) {
+	DynamicFPSConfig(int abandonTime, boolean uncapMenuFrameRate, Map<PowerState, Config> configs) {
 		this.idleTime = abandonTime;
+		this.uncapMenuFrameRate = uncapMenuFrameRate;
+
 		this.configs = new EnumMap<>(configs);
 
 		for (PowerState state : PowerState.values()) {
@@ -36,6 +40,14 @@ public final class DynamicFPSConfig {
 
 	public void setIdleTime(int value) {
 		this.idleTime = value;
+	}
+
+	public boolean uncapMenuFrameRate() {
+		return this.uncapMenuFrameRate;
+	}
+
+	public void setUncapMenuFrameRate(boolean value) {
+		this.uncapMenuFrameRate = value;
 	}
 
 	private Map<PowerState, Config> configs() {

--- a/src/main/java/dynamic_fps/impl/config/Serialization.java
+++ b/src/main/java/dynamic_fps/impl/config/Serialization.java
@@ -67,7 +67,7 @@ public class Serialization {
 		try {
 			data = Files.readAllBytes(CONFIG_FILE);
 		} catch (NoSuchFileException e) {
-			DynamicFPSConfig config = new DynamicFPSConfig(0, new EnumMap<>(PowerState.class));
+			DynamicFPSConfig config = new DynamicFPSConfig(0, false, new EnumMap<>(PowerState.class));
 			config.save();
 			return config;
 		} catch (IOException e) {
@@ -84,6 +84,7 @@ public class Serialization {
 		addIdleTime(root);
 		upgradeVolumeMultiplier(root);
 		addAbandonedConfig(root);
+		addUncapMenuFrameRate(root);
 	}
 
 	private static void addIdleTime(JsonObject root) {
@@ -142,6 +143,13 @@ public class Serialization {
 		}
 
 		states.add("abandoned", GSON.toJsonTree(Config.getDefault(PowerState.ABANDONED)));
+	}
+
+	private static void addUncapMenuFrameRate(JsonObject root) {
+		// Add uncap_menu_frame_rate field if it's missing
+		if (!root.has("uncap_menu_frame_rate")) {
+			root.addProperty("uncap_menu_frame_rate", false);
+		}
 	}
 
 	private static @Nullable JsonObject getStatesAsObject(JsonObject root) {

--- a/src/main/java/dynamic_fps/impl/mixin/MinecraftMixin.java
+++ b/src/main/java/dynamic_fps/impl/mixin/MinecraftMixin.java
@@ -1,16 +1,17 @@
 package dynamic_fps.impl.mixin;
 
+import com.mojang.blaze3d.platform.Window;
+import dynamic_fps.impl.DynamicFPSMod;
+import dynamic_fps.impl.PowerState;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.Options;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-
-import com.mojang.blaze3d.platform.Window;
-
-import dynamic_fps.impl.DynamicFPSMod;
-import net.minecraft.client.Minecraft;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(Minecraft.class)
 public class MinecraftMixin {
@@ -18,15 +19,43 @@ public class MinecraftMixin {
 	@Final
     private Window window;
 
+	@Shadow
+	@Final
+	public Options options;
+
+	// Minecraft considers limits >=260 as infinite
+	private static final int NO_FRAME_RATE_LIMIT = 260;
+
 	@Inject(method = "<init>", at = @At("TAIL"))
 	private void onInit(CallbackInfo callbackInfo) {
 		DynamicFPSMod.setWindow(this.window.window);
 	}
 
-	/*
-	@Inject(method = "setScreen", at = @At("TAIL"))
-	private void onSetScreen(CallbackInfo callbackInfo) {
-		DynamicFPSMod.onStatusChanged();
+	/**
+	 * Conditionally bypasses the main menu frame rate limit.
+	 *
+	 * This is done in two cases:
+	 * - The window is active, and the user wants to uncap the frame rate
+	 * - The window is inactive, and the current FPS limit should be lower
+	 */
+	@Inject(method = "getFramerateLimit", at = @At(value = "CONSTANT", args = "intValue=60"), cancellable = true)
+	private void getFramerateLimit(CallbackInfoReturnable<Integer> callbackInfo) {
+		int limit = this.window.getFramerateLimit();
+
+		if (DynamicFPSMod.powerState() != PowerState.FOCUSED) {
+			// Limit may be 260 (uncapped)
+			if (limit < 60) {
+				callbackInfo.setReturnValue(limit);
+			}
+		} else if (DynamicFPSMod.uncapMenuFrameRate()) {
+			if (this.options.enableVsync().get()) {
+				// VSync will regulate to a non-infinite value
+				callbackInfo.setReturnValue(NO_FRAME_RATE_LIMIT);
+			} else {
+				// Even though the option "uncaps" the frame rate the max is 250 FPS
+				// Since otherwise this will just cause coil whine for no real benefit.
+				callbackInfo.setReturnValue(Math.min(limit, NO_FRAME_RATE_LIMIT - 10));
+			}
+		}
 	}
-	*/
 }

--- a/src/main/resources/assets/dynamic_fps/lang/en_us.json
+++ b/src/main/resources/assets/dynamic_fps/lang/en_us.json
@@ -13,6 +13,9 @@
 	"config.dynamic_fps.idle_time": "Idle time",
 	"config.dynamic_fps.idle_time_tooltip": "Minutes without input until Dynamic FPS activates the Idle state while the game is focused.",
 
+	"config.dynamic_fps.uncap_menu_frame_rate": "Uncap Menu FPS",
+	"config.dynamic_fps.uncap_menu_frame_rate_tooltip": "Remove the 60 FPS limit in the main menu.",
+
 	"config.dynamic_fps.frame_rate_target": "Frame Rate Target",
 	"config.dynamic_fps.volume_multiplier": "Volume Multiplier",
 


### PR DESCRIPTION
Allows disabling the 60 FPS limit in the menu.

With VSync enabled it'll completely uncap the FPS, otherwise limit it to the user's limit or 250 (to prevent coil whine).