### PR TITLE
Fix the GLFW mouse workaround applying when reducing FPS via keybind

### DIFF
--- a/platforms/common/src/main/java/dynamic_fps/impl/DynamicFPSMod.java
+++ b/platforms/common/src/main/java/dynamic_fps/impl/DynamicFPSMod.java
@@ -60,6 +60,14 @@ public class DynamicFPSMod {
 		return isKeybindDisabled;
 	}
 
+	public static WindowObserver getWindow() {
+		if (window != null) {
+			return window;
+		}
+
+		throw new RuntimeException("Accessed window too early!");
+	}
+
 	public static boolean isDisabled() {
 		return isKeybindDisabled || !modConfig.enabled() || ModCompat.getInstance().isDisabled();
 	}
@@ -207,22 +215,11 @@ public class DynamicFPSMod {
 		Config before = config;
 		config = modConfig.get(current);
 
+		GLFW.applyWorkaround(); // Apply mouse hover fix if required
 		hasRenderedLastFrame = false; // Render next frame w/o delay
 
 		if (config.runGarbageCollector()) {
 			System.gc();
-		}
-
-		if (GLFW.useHoverEventWorkaround()) {
-			if (!current.windowActive) {
-				minecraft.mouseHandler.releaseMouse();
-			} else {
-				// Grabbing the mouse only works while Minecraft
-				// Agrees that the window is focused. The mod is
-				// A little too fast for this, so we schedule it
-				// For the next client tick (before next frame).
-				minecraft.tell(minecraft.mouseHandler::grabMouse);
-			}
 		}
 
 		for (SoundSource source : SoundSource.values()) {

--- a/platforms/common/src/main/java/dynamic_fps/impl/PowerState.java
+++ b/platforms/common/src/main/java/dynamic_fps/impl/PowerState.java
@@ -9,33 +9,31 @@ public enum PowerState {
 	/**
 	 * Window is currently focused.
 	 */
-	FOCUSED(false, true),
+	FOCUSED(false),
 
 	/**
 	 * Mouse positioned over unfocused window.
 	 */
-	HOVERED(true, false),
+	HOVERED(true),
 
 	/**
 	 * Another application is focused.
 	 */
-	UNFOCUSED(true, false),
+	UNFOCUSED(true),
 
 	/**
 	 * User hasn't sent input for some time.
 	 */
-	ABANDONED(true, true),
+	ABANDONED(true),
 
 	/**
 	 * Window minimized or otherwise hidden.
 	 */
-	INVISIBLE(true, false);
+	INVISIBLE(true);
 
 	public final boolean configurable;
-	public final boolean windowActive;
 
-	private PowerState(boolean configurable, boolean windowActive) {
+	private PowerState(boolean configurable) {
 		this.configurable = configurable;
-		this.windowActive = windowActive;
 	}
 }

--- a/platforms/common/src/main/java/dynamic_fps/impl/compat/GLFW.java
+++ b/platforms/common/src/main/java/dynamic_fps/impl/compat/GLFW.java
@@ -1,5 +1,6 @@
 package dynamic_fps.impl.compat;
 
+import dynamic_fps.impl.DynamicFPSMod;
 import net.minecraft.client.Minecraft;
 
 public class GLFW {
@@ -7,14 +8,30 @@ public class GLFW {
 	private static final boolean enterEventBroken = isEnterEventBroken();
 
 	/**
-	 * Whether to use a workaround for the cursor enter event not working.
+	 * Apply a workaround for the cursor enter event not working if needed.
 	 *
 	 * This fixes an issue when running GLFW version 3.3.x or earlier where
 	 * the cursor enter event will only work if the window is not capturing
 	 * The mouse cursor. Since this is often not the case when switching windows
 	 * Dynamic FPS releases and captures the cursor in tandem with window focus.
 	 */
-	public static boolean useHoverEventWorkaround() {
+	public static void applyWorkaround() {
+		if (!useWorkaround()) {
+			return;
+		}
+
+		if (!DynamicFPSMod.getWindow().isFocused()) {
+			minecraft.mouseHandler.releaseMouse();
+		} else {
+			// Grabbing the mouse only works while Minecraft
+			// Agrees that the window is focused. The mod is
+			// A little too fast for this, so we schedule it
+			// For the next client tick (before next frame).
+			minecraft.tell(minecraft.mouseHandler::grabMouse);
+		}
+	}
+
+	private static boolean useWorkaround() {
 		return enterEventBroken && minecraft.screen == null && !minecraft.options.pauseOnLostFocus;
 	}
 


### PR DESCRIPTION
Fix the mouse cursor being released when using the reduce keybind on Minecraft 1.18.2 and earlier.
