### PR TITLE
Add workaround for softlock in combination with Fastload

### DIFF
--- a/platforms/common/src/main/java/dynamic_fps/impl/DynamicFPSMod.java
+++ b/platforms/common/src/main/java/dynamic_fps/impl/DynamicFPSMod.java
@@ -5,6 +5,7 @@ import dynamic_fps.impl.config.Config;
 import dynamic_fps.impl.config.DynamicFPSConfig;
 import dynamic_fps.impl.service.ModCompat;
 import dynamic_fps.impl.util.Logging;
+import dynamic_fps.impl.util.ModCompatHelper;
 import dynamic_fps.impl.util.OptionsHolder;
 import dynamic_fps.impl.util.duck.DuckScreen;
 import dynamic_fps.impl.util.duck.DuckLoadingOverlay;
@@ -52,8 +53,12 @@ public class DynamicFPSMod {
 	// Internal "API" for Dynamic FPS itself
 
 	public static void init() {
+		ModCompatHelper.init();
+
 		Platform platform = Platform.getInstance();
-		Logging.getLogger().info("Dynamic FPS {} active on {}!", platform.modVersion(), platform.getName());
+		String version = platform.getModVersion(Constants.MOD_ID).orElseThrow();
+
+		Logging.getLogger().info("Dynamic FPS {} active on {}!", version, platform.getName());
 	}
 
 	public static boolean disabledByUser() {

--- a/platforms/common/src/main/java/dynamic_fps/impl/service/ModCompat.java
+++ b/platforms/common/src/main/java/dynamic_fps/impl/service/ModCompat.java
@@ -1,11 +1,21 @@
 package dynamic_fps.impl.service;
 
+import java.util.Set;
+
 public interface ModCompat {
 	boolean isDisabled();
 
 	boolean disableOverlayOptimization();
-	boolean isScreenOptedIn(String className);
-	boolean isScreenOptedOut(String className);
+	Set<String> getOptedInScreens();
+	Set<String> getOptedOutScreens();
+
+	default boolean isScreenOptedIn(String className) {
+		return getOptedInScreens().contains(className);
+	}
+
+	default boolean isScreenOptedOut(String className) {
+		return getOptedOutScreens().contains(className);
+	}
 
 	static ModCompat getInstance() {
 		return Services.MOD_COMPAT;

--- a/platforms/common/src/main/java/dynamic_fps/impl/service/Platform.java
+++ b/platforms/common/src/main/java/dynamic_fps/impl/service/Platform.java
@@ -1,14 +1,16 @@
 package dynamic_fps.impl.service;
 
 import java.nio.file.Path;
+import java.util.Optional;
 
 public interface Platform {
 	String getName();
-	String modVersion();
 
 	Path getCacheDir();
 	Path getConfigDir();
 	boolean isDevelopmentEnvironment();
+
+	Optional<String> getModVersion(String modId);
 
 	void registerStartTickEvent(StartTickEvent event);
 

--- a/platforms/common/src/main/java/dynamic_fps/impl/util/ModCompatHelper.java
+++ b/platforms/common/src/main/java/dynamic_fps/impl/util/ModCompatHelper.java
@@ -1,0 +1,42 @@
+package dynamic_fps.impl.util;
+
+import dynamic_fps.impl.service.ModCompat;
+import dynamic_fps.impl.service.Platform;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+public class ModCompatHelper {
+	public static void init() {
+		fixFastloadSoftLock();
+	}
+
+	/**
+	 * Fix softlock in combination with Fastload <=3.4.0 due to our screen / loading overlay optimization.
+	 *
+	 * See the <a href="https://github.com/juliand665/Dynamic-FPS/issues/129">issue report</a> for more info.
+	 */
+	private static void fixFastloadSoftLock() {
+		Optional<String> optional = Platform.getInstance().getModVersion("fastload");
+
+		if (optional.isEmpty()) {
+			return;
+		}
+
+		String[] parts = optional.get().split("\\.");
+		int[] version = Arrays.stream(parts).mapToInt(Integer::parseInt).toArray();
+
+		if (version.length < 3) {
+			Logging.getLogger().warn("Unable to parse Fastload version: {}!", optional.get());
+			return;
+		}
+
+		// If a version below 3.4.0 is present opt their custom world loading screen out of our optimization
+		if (!(version[0] > 3 || version[0] == 3 && (version[1] > 4 || version[1] == 4 && version[2] > 0))) {
+			ModCompat.getInstance().getOptedOutScreens().add(
+				"io.github.bumblesoftware.fastload.client.BuildingTerrainScreen"
+			);
+
+		}
+	}
+}

--- a/platforms/fabric/src/main/java/net/lostluma/dynamic_fps/impl/fabric/service/FabricModCompat.java
+++ b/platforms/fabric/src/main/java/net/lostluma/dynamic_fps/impl/fabric/service/FabricModCompat.java
@@ -33,13 +33,13 @@ public class FabricModCompat implements ModCompat {
 	}
 
 	@Override
-	public boolean isScreenOptedIn(String className) {
-		return optedInScreens.contains(className);
+	public Set<String> getOptedInScreens() {
+		return optedInScreens;
 	}
 
 	@Override
-	public boolean isScreenOptedOut(String className) {
-		return optedOutScreens.contains(className);
+	public Set<String> getOptedOutScreens() {
+		return optedOutScreens;
 	}
 
 	private static void parseModMetadata(ModContainer mod) {

--- a/platforms/fabric/src/main/java/net/lostluma/dynamic_fps/impl/fabric/service/FabricPlatform.java
+++ b/platforms/fabric/src/main/java/net/lostluma/dynamic_fps/impl/fabric/service/FabricPlatform.java
@@ -18,17 +18,6 @@ public class FabricPlatform implements Platform {
 	}
 
 	@Override
-	public String modVersion() {
-		Optional<ModContainer> optional = FabricLoader.getInstance().getModContainer(Constants.MOD_ID);
-
-		if (optional.isPresent()) {
-			return optional.get().getMetadata().getVersion().getFriendlyString();
-		} else {
-			throw new RuntimeException("Own mod container is somehow not available!");
-		}
-	}
-
-	@Override
 	public Path getCacheDir() {
 		Path base = FabricLoader.getInstance().getGameDir();
 		return this.ensureDir(base.resolve(".cache").resolve(Constants.MOD_ID));
@@ -42,6 +31,12 @@ public class FabricPlatform implements Platform {
 	@Override
 	public boolean isDevelopmentEnvironment() {
 		return FabricLoader.getInstance().isDevelopmentEnvironment();
+	}
+
+	@Override
+	public Optional<String> getModVersion(String modId) {
+		Optional<ModContainer> optional = FabricLoader.getInstance().getModContainer(modId);
+		return optional.map(modContainer -> modContainer.getMetadata().getVersion().toString());
 	}
 
 	@Override

--- a/platforms/fabric/src/main/resources/fabric.mod.json
+++ b/platforms/fabric/src/main/resources/fabric.mod.json
@@ -41,9 +41,6 @@
         "cloth-config": "*",
         "quilt_loader": "*"
     },
-    "breaks": {
-        "fastload": "<=3.4.0"
-    },
     "mixins": [
         "dynamic_fps.mixins.json",
         "dynamic_fps-common.mixins.json"

--- a/platforms/forge/src/main/java/net/lostluma/dynamic_fps/impl/forge/service/ForgeModCompat.java
+++ b/platforms/forge/src/main/java/net/lostluma/dynamic_fps/impl/forge/service/ForgeModCompat.java
@@ -4,7 +4,16 @@ import dynamic_fps.impl.service.ModCompat;
 import net.minecraft.client.gui.screens.ReceivingLevelScreen;
 import net.minecraftforge.fml.ModList;
 
+import java.util.HashSet;
+import java.util.Set;
+
 public class ForgeModCompat implements ModCompat {
+	private static final Set<String> optedOutScreens = new HashSet<>();
+
+	static {
+		optedOutScreens.add(ReceivingLevelScreen.class.getCanonicalName());
+	}
+
 	@Override
 	public boolean isDisabled() {
 		return false;
@@ -16,12 +25,12 @@ public class ForgeModCompat implements ModCompat {
 	}
 
 	@Override
-	public boolean isScreenOptedIn(String className) {
-		return false;
+	public Set<String> getOptedInScreens() {
+		return Set.of();
 	}
 
 	@Override
-	public boolean isScreenOptedOut(String className) {
-		return ReceivingLevelScreen.class.getCanonicalName().equals(className);
+	public Set<String> getOptedOutScreens() {
+		return optedOutScreens;
 	}
 }

--- a/platforms/forge/src/main/java/net/lostluma/dynamic_fps/impl/forge/service/ForgePlatform.java
+++ b/platforms/forge/src/main/java/net/lostluma/dynamic_fps/impl/forge/service/ForgePlatform.java
@@ -14,21 +14,9 @@ import java.nio.file.Path;
 import java.util.Optional;
 
 public class ForgePlatform implements Platform {
-
 	@Override
 	public String getName() {
 		return "Forge";
-	}
-
-	@Override
-	public String modVersion() {
-		Optional<? extends ModContainer> optional = ModList.get().getModContainerById(Constants.MOD_ID);
-
-		if (optional.isPresent()) {
-			return optional.get().getModInfo().getVersion().toString();
-		} else {
-			throw new RuntimeException("Own mod container is somehow not available!");
-		}
 	}
 
 	@Override
@@ -45,6 +33,12 @@ public class ForgePlatform implements Platform {
 	@Override
 	public boolean isDevelopmentEnvironment() {
 		return !FMLLoader.isProduction();
+	}
+
+	@Override
+	public Optional<String> getModVersion(String modId) {
+		Optional<? extends ModContainer> optional = ModList.get().getModContainerById(modId);
+		return optional.map(modContainer -> modContainer.getModInfo().getVersion().toString());
 	}
 
 	@Override

--- a/platforms/neoforge/src/main/java/net/lostluma/dynamic_fps/impl/neoforge/service/NeoForgeModCompat.java
+++ b/platforms/neoforge/src/main/java/net/lostluma/dynamic_fps/impl/neoforge/service/NeoForgeModCompat.java
@@ -4,7 +4,16 @@ import dynamic_fps.impl.service.ModCompat;
 import net.minecraft.client.gui.screens.ReceivingLevelScreen;
 import net.neoforged.fml.ModList;
 
+import java.util.HashSet;
+import java.util.Set;
+
 public class NeoForgeModCompat implements ModCompat {
+	private static final Set<String> optedOutScreens = new HashSet<>();
+
+	static {
+		optedOutScreens.add(ReceivingLevelScreen.class.getCanonicalName());
+	}
+
 	@Override
 	public boolean isDisabled() {
 		return false;
@@ -16,12 +25,12 @@ public class NeoForgeModCompat implements ModCompat {
 	}
 
 	@Override
-	public boolean isScreenOptedIn(String className) {
-		return false;
+	public Set<String> getOptedInScreens() {
+		return Set.of();
 	}
 
 	@Override
-	public boolean isScreenOptedOut(String className) {
-		return ReceivingLevelScreen.class.getCanonicalName().equals(className);
+	public Set<String> getOptedOutScreens() {
+		return optedOutScreens;
 	}
 }

--- a/platforms/neoforge/src/main/java/net/lostluma/dynamic_fps/impl/neoforge/service/NeoForgePlatform.java
+++ b/platforms/neoforge/src/main/java/net/lostluma/dynamic_fps/impl/neoforge/service/NeoForgePlatform.java
@@ -2,15 +2,11 @@ package net.lostluma.dynamic_fps.impl.neoforge.service;
 
 import dynamic_fps.impl.Constants;
 import dynamic_fps.impl.service.Platform;
-import net.neoforged.bus.EventBus;
-import net.neoforged.bus.api.IEventBus;
 import net.neoforged.fml.ModContainer;
 import net.neoforged.fml.ModList;
 import net.neoforged.fml.loading.FMLLoader;
 import net.neoforged.fml.loading.FMLPaths;
-import net.neoforged.neoforge.client.ClientHooks;
 import net.neoforged.neoforge.common.NeoForge;
-import net.neoforged.neoforge.common.NeoForgeEventHandler;
 import net.neoforged.neoforge.event.TickEvent;
 
 import java.io.IOException;
@@ -22,17 +18,6 @@ public class NeoForgePlatform implements Platform {
 	@Override
 	public String getName() {
 		return "NeoForge";
-	}
-
-	@Override
-	public String modVersion() {
-		Optional<? extends ModContainer> optional = ModList.get().getModContainerById(Constants.MOD_ID);
-
-		if (optional.isPresent()) {
-			return optional.get().getModInfo().getVersion().toString();
-		} else {
-			throw new RuntimeException("Own mod container is somehow not available!");
-		}
 	}
 
 	@Override
@@ -49,6 +34,12 @@ public class NeoForgePlatform implements Platform {
 	@Override
 	public boolean isDevelopmentEnvironment() {
 		return !FMLLoader.isProduction();
+	}
+
+	@Override
+	public Optional<String> getModVersion(String modId) {
+		Optional<? extends ModContainer> optional = ModList.get().getModContainerById(modId);
+		return optional.map(modContainer -> modContainer.getModInfo().getVersion().toString());
 	}
 
 	@Override

--- a/platforms/quilt/src/main/java/net/lostluma/dynamic_fps/impl/quilt/service/QuiltModCompat.java
+++ b/platforms/quilt/src/main/java/net/lostluma/dynamic_fps/impl/quilt/service/QuiltModCompat.java
@@ -33,13 +33,13 @@ public class QuiltModCompat implements ModCompat {
 	}
 
 	@Override
-	public boolean isScreenOptedIn(String className) {
-		return optedInScreens.contains(className);
+	public Set<String> getOptedInScreens() {
+		return optedInScreens;
 	}
 
 	@Override
-	public boolean isScreenOptedOut(String className) {
-		return optedOutScreens.contains(className);
+	public Set<String> getOptedOutScreens() {
+		return optedOutScreens;
 	}
 
 	private static void parseModMetadata(ModContainer mod) {

--- a/platforms/quilt/src/main/java/net/lostluma/dynamic_fps/impl/quilt/service/QuiltPlatform.java
+++ b/platforms/quilt/src/main/java/net/lostluma/dynamic_fps/impl/quilt/service/QuiltPlatform.java
@@ -18,17 +18,6 @@ public class QuiltPlatform implements Platform {
 	}
 
 	@Override
-	public String modVersion() {
-		Optional<ModContainer> optional = QuiltLoader.getModContainer(Constants.MOD_ID);
-
-		if (optional.isPresent()) {
-			return optional.get().metadata().version().toString();
-		} else {
-			throw new RuntimeException("Own mod container is somehow not available!");
-		}
-	}
-
-	@Override
 	public Path getCacheDir() {
 		return this.ensureDir(QuiltLoader.getCacheDir().resolve(Constants.MOD_ID));
 	}
@@ -41,6 +30,12 @@ public class QuiltPlatform implements Platform {
 	@Override
 	public boolean isDevelopmentEnvironment() {
 		return QuiltLoader.isDevelopmentEnvironment();
+	}
+
+	@Override
+	public Optional<String> getModVersion(String modId) {
+		Optional<ModContainer> optional = QuiltLoader.getModContainer(modId);
+		return optional.map(modContainer -> modContainer.metadata().version().toString());
 	}
 
 	@Override

--- a/platforms/quilt/src/main/resources/quilt.mod.json
+++ b/platforms/quilt/src/main/resources/quilt.mod.json
@@ -64,13 +64,6 @@
                 "versions": "*",
                 "optional": true
             }
-        ],
-        "breaks": [
-            {
-                "id": "fastload",
-                "versions": "<=3.4.0",
-                "reason": "Softlock in world loading screen, see https://github.com/BumbleSoftware/Fastload/issues/108"
-            }
         ]
     },
     "minecraft": {


### PR DESCRIPTION
Resolves #169.

Adds a check for current and older Fastload versions, and disables our screen optimization if this is the case.