### PR TITLE
Smooth volume transition

### DIFF
--- a/platforms/common/src/main/java/dynamic_fps/impl/DynamicFPSMod.java
+++ b/platforms/common/src/main/java/dynamic_fps/impl/DynamicFPSMod.java
@@ -10,6 +10,7 @@ import dynamic_fps.impl.util.FallbackConfigScreen;
 import dynamic_fps.impl.util.Logging;
 import dynamic_fps.impl.util.OptionsHolder;
 import dynamic_fps.impl.util.Version;
+import dynamic_fps.impl.util.SmoothVolumeHandler;
 import dynamic_fps.impl.util.duck.DuckLoadingOverlay;
 import dynamic_fps.impl.util.duck.DuckSoundEngine;
 import dynamic_fps.impl.util.event.WindowObserver;
@@ -52,6 +53,7 @@ public class DynamicFPSMod {
 
 	public static void init() {
 		IdleHandler.init();
+		SmoothVolumeHandler.init();
 
 		Platform platform = Platform.getInstance();
 		Version version = platform.getModVersion(Constants.MOD_ID).orElseThrow();
@@ -97,6 +99,7 @@ public class DynamicFPSMod {
 	public static void onConfigChanged() {
 		modConfig.save();
 		IdleHandler.init();
+		SmoothVolumeHandler.init();
 	}
 
 	public static Screen getConfigScreen(Screen parent) {
@@ -159,6 +162,10 @@ public class DynamicFPSMod {
 		return config.volumeMultiplier(source);
 	}
 
+	public static DynamicFPSConfig.VolumeTransitionSpeed volumeTransitionSpeed() {
+		return modConfig.volumeTransitionSpeed();
+	}
+
 	public static boolean shouldShowToasts() {
 		return config.showToasts();
 	}
@@ -189,6 +196,7 @@ public class DynamicFPSMod {
 			System.gc();
 		}
 
+		// Update volume of current sounds for users not using smooth volume transition
 		for (SoundSource source : SoundSource.values()) {
 			((DuckSoundEngine) minecraft.getSoundManager().soundEngine).dynamic_fps$updateVolume(source);
 		}

--- a/platforms/common/src/main/java/dynamic_fps/impl/DynamicFPSMod.java
+++ b/platforms/common/src/main/java/dynamic_fps/impl/DynamicFPSMod.java
@@ -197,8 +197,10 @@ public class DynamicFPSMod {
 		}
 
 		// Update volume of current sounds for users not using smooth volume transition
-		for (SoundSource source : SoundSource.values()) {
-			((DuckSoundEngine) minecraft.getSoundManager().soundEngine).dynamic_fps$updateVolume(source);
+		if (!volumeTransitionSpeed().isActive()) {
+			for (SoundSource source : SoundSource.values()) {
+				((DuckSoundEngine) minecraft.getSoundManager().soundEngine).dynamic_fps$updateVolume(source);
+			}
 		}
 
 		if (before.graphicsState() != config.graphicsState()) {

--- a/platforms/common/src/main/java/dynamic_fps/impl/compat/ClothConfig.java
+++ b/platforms/common/src/main/java/dynamic_fps/impl/compat/ClothConfig.java
@@ -72,6 +72,34 @@ public final class ClothConfig {
 			.build()
 		);
 
+		VariableStepTransformer volumeTransformer = getVolumeStepTransformer();
+
+		general.addEntry(
+			entryBuilder.startIntSlider(
+					localized("config", "volume_transition_speed_up"),
+					volumeTransformer.toStep((int) (DynamicFPSMod.volumeTransitionSpeed().getUp() * 10)),
+					1, 31
+				)
+				.setDefaultValue(volumeTransformer.toStep((int) (1.0f * 10)))
+				.setSaveConsumer(step -> DynamicFPSMod.volumeTransitionSpeed().setUp((float) volumeTransformer.toValue(step) / 10))
+				.setTextGetter(ClothConfig::volumeTransitionMessage)
+				.setTooltip(localized("config", "volume_transition_speed_tooltip"))
+				.build()
+		);
+
+		general.addEntry(
+			entryBuilder.startIntSlider(
+					localized("config", "volume_transition_speed_down"),
+					volumeTransformer.toStep((int) (DynamicFPSMod.volumeTransitionSpeed().getDown() * 10)),
+					1, 31
+				)
+				.setDefaultValue(volumeTransformer.toStep((int) (0.5f * 10)))
+				.setSaveConsumer(step -> DynamicFPSMod.volumeTransitionSpeed().setDown((float) volumeTransformer.toValue(step) / 10))
+				.setTextGetter(ClothConfig::volumeTransitionMessage)
+				.setTooltip(localized("config", "volume_transition_speed_tooltip"))
+				.build()
+		);
+
 		// Used for each state's frame rate target slider below
 		VariableStepTransformer fpsTransformer = getFpsTransformer();
 
@@ -166,6 +194,25 @@ public final class ClothConfig {
 			return localized("config", "disabled");
 		} else {
 			return localized("config", "minutes", value);
+		}
+	}
+
+	private static VariableStepTransformer getVolumeStepTransformer() {
+		VariableStepTransformer transformer = new VariableStepTransformer();
+
+		transformer.addStep(1, 30);
+		transformer.addStep(970, 1000);
+
+		return transformer;
+	}
+
+	private static Component volumeTransitionMessage(int step) {
+		float value = (float) getVolumeStepTransformer().toValue(step) / 10;
+
+		if (value < 100.0f) {
+			return Component.literal(value + "%");
+		} else {
+			return localized("config", "volume_transition_speed_instant");
 		}
 	}
 

--- a/platforms/common/src/main/java/dynamic_fps/impl/config/DynamicFPSConfig.java
+++ b/platforms/common/src/main/java/dynamic_fps/impl/config/DynamicFPSConfig.java
@@ -11,15 +11,17 @@ public final class DynamicFPSConfig {
 	private int idleTime; // Seconds
 	private boolean detectIdleMovement;
 	private boolean uncapMenuFrameRate;
+	private VolumeTransitionSpeed volumeTransitionSpeed;
 
 	@SerializedName("states")
 	private final Map<PowerState, Config> configs;
 
-	private DynamicFPSConfig(boolean enabled, int abandonTime, boolean detectIdleMovement, boolean uncapMenuFrameRate, Map<PowerState, Config> configs) {
+	private DynamicFPSConfig(boolean enabled, int abandonTime, boolean detectIdleMovement, boolean uncapMenuFrameRate, VolumeTransitionSpeed volumeTransitionSpeed, Map<PowerState, Config> configs) {
 		this.enabled = enabled;
 		this.idleTime = abandonTime;
 		this.detectIdleMovement = detectIdleMovement;
 		this.uncapMenuFrameRate = uncapMenuFrameRate;
+		this.volumeTransitionSpeed = volumeTransitionSpeed;
 
 		this.configs = new EnumMap<>(configs);
 
@@ -36,6 +38,7 @@ public final class DynamicFPSConfig {
 			0,
 			true,
 			false,
+			new VolumeTransitionSpeed(1.0f, 0.5f),
 			new EnumMap<>(PowerState.class)
 		);
 
@@ -67,6 +70,10 @@ public final class DynamicFPSConfig {
 		this.idleTime = value;
 	}
 
+	public VolumeTransitionSpeed volumeTransitionSpeed() {
+		return this.volumeTransitionSpeed;
+	}
+
 	public boolean detectIdleMovement() {
 		return this.detectIdleMovement;
 	}
@@ -95,5 +102,35 @@ public final class DynamicFPSConfig {
 
 	public void save() {
 		Serialization.save(this);
+	}
+
+	public static class VolumeTransitionSpeed {
+		private float up;
+		private float down;
+
+		protected VolumeTransitionSpeed(float up, float down) {
+			this.up = up;
+			this.down = down;
+		}
+
+		public float getUp() {
+			return this.up;
+		}
+
+		public void setUp(float value) {
+			this.up = value;
+		}
+
+		public float getDown() {
+			return this.down;
+		}
+
+		public void setDown(float value) {
+			this.down = value;
+		}
+
+		public boolean isActive() {
+			return this.up != 100.0f || this.down != 100.0f;
+		}
 	}
 }

--- a/platforms/common/src/main/java/dynamic_fps/impl/config/Serialization.java
+++ b/platforms/common/src/main/java/dynamic_fps/impl/config/Serialization.java
@@ -100,6 +100,7 @@ public class Serialization {
 		addUncapMenuFrameRate(root);
 		addEnabled(root);
 		addDetectIdleMovement(root);
+		addVolumeTransitionSpeed(root);
 	}
 
 	private static void addIdleTime(JsonObject root) {
@@ -178,6 +179,18 @@ public class Serialization {
 		// Add detect_idle_movement field if it's missing
 		if (!root.has("detect_idle_movement")) {
 			root.addProperty("detect_idle_movement", true);
+		}
+	}
+
+	private static void addVolumeTransitionSpeed(JsonObject root) {
+		// Add volume_transition_speed object if it's missing
+		if (!root.has("volume_transition_speed")) {
+			JsonObject object = new JsonObject();
+
+			object.addProperty("up", 1.0f);
+			object.addProperty("down", 0.5f);
+
+			root.add("volume_transition_speed", object);
 		}
 	}
 

--- a/platforms/common/src/main/java/dynamic_fps/impl/mixin/SoundEngineMixin.java
+++ b/platforms/common/src/main/java/dynamic_fps/impl/mixin/SoundEngineMixin.java
@@ -2,6 +2,7 @@ package dynamic_fps.impl.mixin;
 
 import java.util.Map;
 
+import dynamic_fps.impl.util.SmoothVolumeHandler;
 import net.minecraft.client.Minecraft;
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Final;
@@ -16,7 +17,6 @@ import com.llamalad7.mixinextras.injector.ModifyReturnValue;
 import com.llamalad7.mixinextras.sugar.Local;
 import com.mojang.blaze3d.audio.Listener;
 
-import dynamic_fps.impl.DynamicFPSMod;
 import dynamic_fps.impl.util.duck.DuckSoundEngine;
 import net.minecraft.client.Options;
 import net.minecraft.client.resources.sounds.SoundInstance;
@@ -104,7 +104,7 @@ public class SoundEngineMixin implements DuckSoundEngine {
 	 */
 	@Inject(method = { "play", "playDelayed" }, at = @At("HEAD"), cancellable = true)
 	private void play(SoundInstance instance, CallbackInfo callbackInfo) {
-		if (DynamicFPSMod.volumeMultiplier(instance.getSource()) == 0.0f) {
+		if (SmoothVolumeHandler.volumeMultiplier(instance.getSource()) == 0.0f) {
 			callbackInfo.cancel();
 		}
 	}
@@ -125,6 +125,6 @@ public class SoundEngineMixin implements DuckSoundEngine {
 			source = SoundSource.MASTER;
 		}
 
-		return value * DynamicFPSMod.volumeMultiplier(source);
+		return value * SmoothVolumeHandler.volumeMultiplier(source);
 	}
 }

--- a/platforms/common/src/main/java/dynamic_fps/impl/util/SmoothVolumeHandler.java
+++ b/platforms/common/src/main/java/dynamic_fps/impl/util/SmoothVolumeHandler.java
@@ -1,0 +1,53 @@
+package dynamic_fps.impl.util;
+
+import dynamic_fps.impl.DynamicFPSMod;
+import dynamic_fps.impl.service.Platform;
+import dynamic_fps.impl.util.duck.DuckSoundEngine;
+import net.minecraft.client.Minecraft;
+import net.minecraft.sounds.SoundSource;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class SmoothVolumeHandler {
+	private static boolean active = false;
+	private static final Minecraft minecraft = Minecraft.getInstance();
+	private static final Map<SoundSource, Float> currentOverrides = new HashMap<>();
+
+	public static void init() {
+		if (active || !DynamicFPSMod.volumeTransitionSpeed().isActive()) {
+			return;
+		}
+
+		active = true;
+		Platform.getInstance().registerStartTickEvent(SmoothVolumeHandler::tickVolumes);
+	}
+
+	public static float volumeMultiplier(SoundSource source) {
+		if (!active) {
+			return DynamicFPSMod.volumeMultiplier(source);
+		} else {
+			return currentOverrides.getOrDefault(source, 1.0f);
+		}
+	}
+
+	private static void tickVolumes() {
+		for (SoundSource source : SoundSource.values()) {
+			float desired = DynamicFPSMod.volumeMultiplier(source);
+			float current = currentOverrides.getOrDefault(source, 1.0f);
+
+			if (current != desired) {
+				if (current < desired) {
+					float up = DynamicFPSMod.volumeTransitionSpeed().getUp();
+					currentOverrides.put(source, Math.min(desired, current + up / 20.0f));
+				} else {
+					float down = DynamicFPSMod.volumeTransitionSpeed().getDown();
+					currentOverrides.put(source, Math.max(desired, current - down / 20.0f));
+				}
+
+				// Update volume of currently playing sounds
+				((DuckSoundEngine) minecraft.getSoundManager().soundEngine).dynamic_fps$updateVolume(source);
+			}
+		}
+	}
+}

--- a/platforms/common/src/main/resources/assets/dynamic_fps/lang/en_us.json
+++ b/platforms/common/src/main/resources/assets/dynamic_fps/lang/en_us.json
@@ -21,6 +21,11 @@
     "config.dynamic_fps.uncap_menu_frame_rate": "Uncap Menu FPS",
     "config.dynamic_fps.uncap_menu_frame_rate_tooltip": "Remove the 60 FPS limit in the main menu.",
 
+    "config.dynamic_fps.volume_transition_speed_up": "Upward Volume Transition Speed",
+    "config.dynamic_fps.volume_transition_speed_down": "Downward Volume Transition Speed",
+    "config.dynamic_fps.volume_transition_speed_instant": "Immediate",
+    "config.dynamic_fps.volume_transition_speed_tooltip": "Set the speed at which the game volume will be adjusted per second.",
+
     "config.dynamic_fps.frame_rate_target": "Frame Rate Target",
     "config.dynamic_fps.volume_multiplier": "Volume Multiplier",
 

--- a/platforms/fabric/src/main/resources/fabric.mod.json
+++ b/platforms/fabric/src/main/resources/fabric.mod.json
@@ -28,6 +28,7 @@
         "LotuxPunk",
         "Madis0",
         "mpustovoi",
+        "N4TH4NOT",
         "notlin4",
         "parly",
         "Pixaurora",

--- a/platforms/forge/src/main/resources/META-INF/mods.toml
+++ b/platforms/forge/src/main/resources/META-INF/mods.toml
@@ -23,6 +23,7 @@ Thanks to:
     DenaryDev
     dima-dencep
     EuropaYou
+    N4TH4NOT
     parly
     Pixaurora
     Setadokalo

--- a/platforms/neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/platforms/neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -23,6 +23,7 @@ Thanks to:
     DenaryDev
     dima-dencep
     EuropaYou
+    N4TH4NOT
     parly
     Pixaurora
     Setadokalo

--- a/platforms/quilt/src/main/resources/quilt.mod.json
+++ b/platforms/quilt/src/main/resources/quilt.mod.json
@@ -14,6 +14,7 @@
                 "DenaryDev": "Contributor",
                 "dima-dencep": "Contributor",
                 "EuropaYou": ["Contributor", "Translator"],
+                "N4TH4NOT": "Contributor",
                 "parly": "Contributor",
                 "Pixaurora": ["Contributor" ,"Translator"],
                 "Setadokalo": "Contributor",


### PR DESCRIPTION
Add a smooth transition when changing between different volume multipliers.

By default this feature will transition volume from 100% to 0% within 2 seconds, and reverse within 1 second.
The speed for both upward and downward transition can be adjusted in the config to be a bit shorter or longer.

---

This was originally [added to Dynamic FPS Reforged](https://github.com/N4TH4NOT/Dynamic-FPS-Reforged/commit/054a50e74066317234d79d9a7059f4d992e53f0c) by @N4TH4NOT before we had sound category support or a Forge version.
Since their idea still influenced this a lot (otherwise I wouldn't have had this idea in the first place) I've added them to our credits.
