### PR TITLE
Allow other mods to disable the overlay optimization on (Neo)Forge

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,16 +35,22 @@ Instead of having to wait for up to a second until the next rendered frame comes
 
 ## Developer Info
 
-> [!IMPORTANT]  
-> These features are currently only accurate for the Fabric and Quilt versions of Dynamic FPS!
+If Dynamic FPS' optimizations conflict with a feature of your mod you can request to disable them.  
+The process of doing so is as simple as adding some additional metadata Dynamic FPS reads to your mod metadata.
 
-If Dynamic FPS' optimizations conflict with a feature of your mod you can disable them.  
-This is done by adding a `dynamic_fps` object to your mod's metadata (inside `quilt`/`fabric.mod.json`).
+**Disable the loading overlay optimization:**
 
-Force disable the loading overlay optimization:
+Fabric / Quilt:
 
 ```json
     "dynamic_fps": {
         "optimized_overlay": false
     },
+```
+
+Forge / NeoForge
+
+```toml
+[modproperties.your_mod_id]
+dynamic_fps = {optimized_overlay = false}
 ```

--- a/platforms/neoforge/src/main/java/net/lostluma/dynamic_fps/impl/neoforge/service/NeoForgeModCompat.java
+++ b/platforms/neoforge/src/main/java/net/lostluma/dynamic_fps/impl/neoforge/service/NeoForgeModCompat.java
@@ -1,9 +1,17 @@
 package net.lostluma.dynamic_fps.impl.neoforge.service;
 
+import com.electronwill.nightconfig.core.CommentedConfig;
 import dynamic_fps.impl.service.ModCompat;
 import net.neoforged.fml.ModList;
+import net.neoforged.neoforgespi.language.IModInfo;
 
 public class NeoForgeModCompat implements ModCompat {
+	private static boolean disableOverlayOptimization = false;
+
+	static {
+		ModList.get().getMods().forEach(NeoForgeModCompat::parseModMetadata);
+	}
+
 	@Override
 	public boolean isDisabled() {
 		return false;
@@ -11,6 +19,20 @@ public class NeoForgeModCompat implements ModCompat {
 
 	@Override
 	public boolean disableOverlayOptimization() {
-		return ModList.get().isLoaded("rrls");
+		return disableOverlayOptimization || ModList.get().isLoaded("rrls");
+	}
+
+	private static void parseModMetadata(IModInfo modInfo) {
+		Object config = modInfo.getModProperties().get("dynamic_fps");
+
+		if (config == null) {
+			return;
+		}
+
+		Boolean value = ((CommentedConfig) config).get("optimized_overlay");
+
+		if (value != null && !value) {
+			disableOverlayOptimization = true;
+		}
 	}
 }


### PR DESCRIPTION
Same feature as already exists on Fabric / Quilt.  
Will also be copied / adjusted for Forge when backporting.