### PR TITLE
Update Battery to 1.0.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,7 @@ quilt_standard_libraries = "8.0.0-alpha.12+1.20.4"
 
 # Regular libraries
 
-battery = "1.0.0"
+battery = "1.0.1"
 
 # Modding libraries
 


### PR DESCRIPTION
Includes a crash bugfix found in this [changelog](https://github.com/LostLuma/battery/releases/tag/v1.0.1).