### PR TITLE
Add vsync option

### DIFF
--- a/platforms/common/src/main/java/dynamic_fps/impl/DynamicFPSMod.java
+++ b/platforms/common/src/main/java/dynamic_fps/impl/DynamicFPSMod.java
@@ -161,6 +161,10 @@ public class DynamicFPSMod {
 		return config.frameRateTarget();
 	}
 
+	public static boolean enableVsync() {
+		return config.enableVsync();
+	}
+
 	public static float volumeMultiplier(SoundSource source) {
 		return config.volumeMultiplier(source);
 	}
@@ -236,6 +240,13 @@ public class DynamicFPSMod {
 			}
 
 			OptionHolder.applyOptions(minecraft.options, config.graphicsState());
+		}
+
+		// The FOCUSED config doesn't have the user's actual vsync preference sadly ...
+		boolean enableVsync = current != PowerState.FOCUSED ? config.enableVsync() : minecraft.options.enableVsync().get();
+
+		if (enableVsync != before.enableVsync()) {
+			minecraft.getWindow().updateVsync(enableVsync);
 		}
 	}
 

--- a/platforms/common/src/main/java/dynamic_fps/impl/compat/ClothConfig.java
+++ b/platforms/common/src/main/java/dynamic_fps/impl/compat/ClothConfig.java
@@ -217,6 +217,16 @@ public final class ClothConfig {
 				.build()
 			);
 
+			category.addEntry(
+				entryBuilder.startBooleanToggle(
+					Component.translatable("options.vsync"),
+					instance.enableVsync()
+				)
+				.setDefaultValue(standard.enableVsync())
+				.setSaveConsumer(instance::setEnableVsync)
+				.build()
+			);
+
 			// Further options are not allowed since this state is used while active.
 			if (state.configurabilityLevel == PowerState.ConfigurabilityLevel.SOME) {
 				continue;

--- a/platforms/common/src/main/java/dynamic_fps/impl/config/Config.java
+++ b/platforms/common/src/main/java/dynamic_fps/impl/config/Config.java
@@ -11,6 +11,7 @@ import net.minecraft.sounds.SoundSource;
 
 public class Config {
 	private int frameRateTarget;
+	private boolean enableVsync;
 	private final Map<String, Float> volumeMultipliers;
 	private GraphicsState graphicsState;
 	private boolean showToasts;
@@ -18,10 +19,11 @@ public class Config {
 
 	protected transient PowerState state; // Set by main config, allows retrieving values from the default power state config
 
-	public static final Config ACTIVE = new Config(-1, new HashMap<>(), GraphicsState.DEFAULT, true, false);
+	public static final Config ACTIVE = new Config(-1, false, new HashMap<>(), GraphicsState.DEFAULT, true, false);
 
-	public Config(int frameRateTarget, Map<String, Float> volumeMultipliers, GraphicsState graphicsState, boolean showToasts, boolean runGarbageCollector) {
+	public Config(int frameRateTarget, boolean enableVsync, Map<String, Float> volumeMultipliers, GraphicsState graphicsState, boolean showToasts, boolean runGarbageCollector) {
 		this.frameRateTarget = frameRateTarget;
+		this.enableVsync = enableVsync;
 		this.volumeMultipliers = new HashMap<>(volumeMultipliers); // Ensure the map is mutable
 		this.graphicsState = graphicsState;
 		this.showToasts = showToasts;
@@ -42,6 +44,14 @@ public class Config {
 		} else {
 			this.frameRateTarget = value;
 		}
+	}
+
+	public boolean enableVsync() {
+		return this.enableVsync;
+	}
+
+	public void setEnableVsync(boolean value) {
+		this.enableVsync = value;
 	}
 
 	public float volumeMultiplier(SoundSource source) {

--- a/platforms/common/src/main/java/dynamic_fps/impl/mixin/DebugScreenOverlayMixin.java
+++ b/platforms/common/src/main/java/dynamic_fps/impl/mixin/DebugScreenOverlayMixin.java
@@ -29,12 +29,14 @@ public class DebugScreenOverlayMixin {
 			PowerState status = DynamicFPSMod.powerState();
 
 			if (status != PowerState.FOCUSED) {
-				int target = DynamicFPSMod.targetFrameRate();
-				String fps = target == Constants.NO_FRAME_RATE_LIMIT ? "inf" : Integer.toString(target);
+				int fps = DynamicFPSMod.targetFrameRate();
+
+				String vsync = DynamicFPSMod.enableVsync() ? " vsync": "";
+				String target = fps == Constants.NO_FRAME_RATE_LIMIT ? "inf" : Integer.toString(fps);
 
 				result.add(
 					2,
-					this.format("§c[Dynamic FPS] FPS: %s P: %s§r", fps, status.toString().toLowerCase())
+					this.format("§c[Dynamic FPS] FPS: %s%s P: %s§r", target, vsync, status.toString().toLowerCase())
 				);
 			}
 		}

--- a/platforms/common/src/main/resources/assets/dynamic_fps/data/default_config.json
+++ b/platforms/common/src/main/resources/assets/dynamic_fps/data/default_config.json
@@ -21,6 +21,7 @@
     "states": {
         "hovered": {
             "frame_rate_target": 60,
+            "enable_vsync": "false",
             "volume_multipliers": {},
             "graphics_state": "default",
             "show_toasts": true,
@@ -28,6 +29,7 @@
         },
         "unfocused": {
             "frame_rate_target": 1,
+            "enable_vsync": "false",
             "volume_multipliers": {
                 "master": 0.25
             },
@@ -37,6 +39,7 @@
         },
         "invisible": {
             "frame_rate_target": 0,
+            "enable_vsync": "false",
             "volume_multipliers": {
                 "master": 0.0
             },
@@ -45,7 +48,8 @@
             "run_garbage_collector": false
         },
         "unplugged": {
-            "frame_rate_target": 60,
+            "frame_rate_target": -1,
+            "enable_vsync": "true",
             "volume_multipliers": {},
             "graphics_state": "default",
             "show_toasts": true,
@@ -53,6 +57,7 @@
         },
         "abandoned": {
             "frame_rate_target": 10,
+            "enable_vsync": "false",
             "volume_multipliers": {},
             "graphics_state": "default",
             "show_toasts": false,


### PR DESCRIPTION
Add option to enable vsync when switching to a different state.
This option is only enabled by default for the on battery state in the default config.

This isn't the most useful (?), but I figured maybe it's cool to have in modpacks since you don't know the user's actual refresh rate if you want to match it for e.g. the hovered state.