### PR TITLE
Fix runtime modified graphics settings potentially being saved

### DIFF
--- a/platforms/common/src/main/java/dynamic_fps/impl/DynamicFPSMod.java
+++ b/platforms/common/src/main/java/dynamic_fps/impl/DynamicFPSMod.java
@@ -173,6 +173,10 @@ public class DynamicFPSMod {
 		return config.showToasts();
 	}
 
+	public static GraphicsState graphicsState() {
+		return config.graphicsState();
+	}
+
 	public static boolean shouldShowLevels() {
 		return isDisabled() || !isLevelCoveredByOverlay();
 	}

--- a/platforms/common/src/main/java/dynamic_fps/impl/mixin/OptionsMixin.java
+++ b/platforms/common/src/main/java/dynamic_fps/impl/mixin/OptionsMixin.java
@@ -1,0 +1,31 @@
+package dynamic_fps.impl.mixin;
+
+import dynamic_fps.impl.DynamicFPSMod;
+import dynamic_fps.impl.config.option.GraphicsState;
+import dynamic_fps.impl.feature.state.OptionHolder;
+import net.minecraft.client.*;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+/**
+ * Resets runtime modified graphics settings to the user-specified defaults during saving.
+ * Prevents the game from saving the reduced or minimal preset to disk and loading it again.
+ */
+@Mixin(Options.class)
+public abstract class OptionsMixin {
+	@Inject(method = "save", at = @At("HEAD"))
+	private void save0(CallbackInfo callbackInfo) {
+		if (DynamicFPSMod.graphicsState() != GraphicsState.DEFAULT) {
+			OptionHolder.applyOptions(Minecraft.getInstance().options, GraphicsState.DEFAULT);
+		}
+	}
+
+	@Inject(method = "save", at = @At("RETURN"))
+	private void save1(CallbackInfo callbackInfo) {
+		if (DynamicFPSMod.graphicsState() != GraphicsState.DEFAULT) {
+			OptionHolder.applyOptions(Minecraft.getInstance().options, DynamicFPSMod.graphicsState());
+		}
+	}
+}

--- a/platforms/common/src/main/resources/dynamic_fps-common.mixins.json
+++ b/platforms/common/src/main/resources/dynamic_fps-common.mixins.json
@@ -9,8 +9,9 @@
         "GuiMixin",
         "LoadingOverlayMixin",
         "MinecraftMixin",
+        "OptionsMixin",
         "SoundEngineMixin",
-      "ToastManagerMixin",
+        "ToastManagerMixin",
         "bugfix.BlockableEventLoopMixin"
     ],
     "mixins": [],


### PR DESCRIPTION
Resolves #213 by reverting any modified settings while the `Options.save` method is being ran.

This sadly causes an additional world reload if using the `minimal` graphics state, however since this bug is exceedingly rare and users are already discouraged from using the `minimal` setting it I think this solution is acceptable.

Other ways of fixing the issue I've considered are way more work to write, maintain, and port to other Minecraft versions.