### PR TITLE
Add error toast with hints

### DIFF
--- a/platforms/common/src/main/java/dynamic_fps/impl/feature/battery/BaseToast.java
+++ b/platforms/common/src/main/java/dynamic_fps/impl/feature/battery/BaseToast.java
@@ -1,0 +1,75 @@
+package dynamic_fps.impl.feature.battery;
+
+import dynamic_fps.impl.util.ResourceLocations;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.Font;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.components.toasts.Toast;
+import net.minecraft.client.gui.components.toasts.ToastManager;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class BaseToast implements Toast {
+	private long firstRender;
+	private Visibility visibility;
+
+	protected Component title;
+	protected Component description;
+	protected @Nullable ResourceLocation icon;
+
+	private static final ResourceLocation MOD_ICON = ResourceLocations.of("dynamic_fps", "textures/battery/toast/background_icon.png");
+	private static final ResourceLocation BACKGROUND_IMAGE = ResourceLocations.of("dynamic_fps", "textures/battery/toast/background.png");
+
+	protected BaseToast(Component title, Component description, @Nullable ResourceLocation icon) {
+		this.title = title;
+		this.description = description;
+
+		this.icon = icon;
+
+		this.visibility = Visibility.SHOW;
+	}
+
+	@Override
+	public @NotNull Visibility getWantedVisibility() {
+		return this.visibility;
+	}
+
+	@Override
+	public void update(ToastManager toastManager, long currentTime) {
+		if (this.firstRender == 0) {
+			return;
+		}
+
+		if (currentTime - this.firstRender >= 5000.0 * toastManager.getNotificationDisplayTimeMultiplier()) {
+			this.visibility = Visibility.HIDE;
+		}
+	}
+
+	@Override
+	public void render(GuiGraphics graphics, Font font, long currentTime) {
+		if (this.firstRender == 0) {
+			this.onFirstRender();
+			this.firstRender = currentTime;
+		}
+
+		// type, resource, x, y, ?, ?, width, height, width, height
+		graphics.blit(RenderType::guiTextured, BACKGROUND_IMAGE, 0, 0, 0.0f, 0, this.width(), this.height(), this.width(), this.height());
+
+		int x = 8;
+
+		if (this.icon != null) {
+			x += 22;
+
+			graphics.blit(RenderType::guiTextured, MOD_ICON, 2, 2, 0.0f, 0, 8, 8, 8, 8);
+			graphics.blit(RenderType::guiTextured, this.icon, 8, 8, 0.0f, 0, 16, 16, 16, 16);
+		}
+
+		graphics.drawString(Minecraft.getInstance().font, this.title, x, 7, 0x5f3315, false);
+		graphics.drawString(Minecraft.getInstance().font, this.description, x, 18, -16777216, false);
+	}
+
+	public void onFirstRender() {}
+}

--- a/platforms/common/src/main/java/dynamic_fps/impl/feature/battery/BatteryToast.java
+++ b/platforms/common/src/main/java/dynamic_fps/impl/feature/battery/BatteryToast.java
@@ -1,35 +1,16 @@
 package dynamic_fps.impl.feature.battery;
 
-import dynamic_fps.impl.util.ResourceLocations;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.gui.Font;
-import net.minecraft.client.gui.GuiGraphics;
-import net.minecraft.client.gui.components.toasts.Toast;
-import net.minecraft.client.gui.components.toasts.ToastManager;
-import net.minecraft.client.renderer.RenderType;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
-import org.jetbrains.annotations.NotNull;
 
 import static dynamic_fps.impl.util.Localization.localized;
 
-public class BatteryToast implements Toast {
-	private long firstRender;
-
-	private Component title;
-	private Component description;
-	private ResourceLocation icon;
-	private Visibility visibility;
-
+public class BatteryToast extends BaseToast {
 	private static BatteryToast queuedToast;
 
-	private static final ResourceLocation MOD_ICON = ResourceLocations.of("dynamic_fps", "textures/battery/toast/background_icon.png");
-	private static final ResourceLocation BACKGROUND_IMAGE = ResourceLocations.of("dynamic_fps", "textures/battery/toast/background.png");
-
 	private BatteryToast(Component title, ResourceLocation icon) {
-		this.title = title;
-		this.icon = icon;
-		this.visibility = Visibility.SHOW;
+		super(title, Component.empty(), icon);
 	}
 
 	/**
@@ -47,39 +28,12 @@ public class BatteryToast implements Toast {
 	}
 
 	@Override
-	public @NotNull Visibility getWantedVisibility() {
-		return this.visibility;
-	}
-
-	@Override
-	public void update(ToastManager toastManager, long currentTime) {
-		if (this.firstRender == 0) {
-			return;
+	public void onFirstRender() {
+		if (this == queuedToast) {
+			queuedToast = null;
 		}
 
-		if (currentTime - this.firstRender >= 5000.0 * toastManager.getNotificationDisplayTimeMultiplier()) {
-			this.visibility = Visibility.HIDE;
-		}
-	}
-
-	@Override
-	public void render(GuiGraphics graphics, Font font, long currentTime) {
-		if (this.firstRender == 0) {
-			if (this == queuedToast) {
-				queuedToast = null;
-			}
-
-			this.firstRender = currentTime;
-			// Initialize when first rendering so the battery percentage is mostly up-to-date
-			this.description = localized("toast", "battery_charge", BatteryTracker.charge());
-		}
-		// resource, x, y, z, ?, ?, width, height, width, height
-		graphics.blit(RenderType::guiTextured, BACKGROUND_IMAGE, 0, 0, 0.0f, 0, this.width(), this.height(), this.width(), this.height());
-
-		graphics.blit(RenderType::guiTextured, MOD_ICON, 2, 2, 0.0f, 0, 8, 8, 8, 8);
-		graphics.blit(RenderType::guiTextured, this.icon, 8, 8, 0.0f, 0, 16, 16, 16, 16);
-
-		graphics.drawString(Minecraft.getInstance().font, this.title, 30, 7, 0x5f3315, false);
-		graphics.drawString(Minecraft.getInstance().font, this.description, 30, 18, -16777216, false);
+		// Initialize when first rendering so the battery percentage is mostly up-to-date
+		this.description = localized("toast", "battery_charge", BatteryTracker.charge());
 	}
 }

--- a/platforms/common/src/main/java/dynamic_fps/impl/feature/battery/BatteryTracker.java
+++ b/platforms/common/src/main/java/dynamic_fps/impl/feature/battery/BatteryTracker.java
@@ -18,6 +18,8 @@ import java.time.temporal.ChronoUnit;
 import java.util.Collection;
 import java.util.Collections;
 
+import static dynamic_fps.impl.util.Localization.localized;
+
 public class BatteryTracker {
 	private static boolean readInitialData = false;
 
@@ -166,6 +168,16 @@ public class BatteryTracker {
 		} catch (LibraryLoadError e) {
 			// No native backend library is available for this OS or platform
 			Logging.getLogger().warn("Battery tracker feature unavailable!");
+
+			String path;
+
+			if (DynamicFPSConfig.INSTANCE.downloadNatives()) {
+				path = "no_support";
+			} else {
+				path = "no_library";
+			}
+
+			ErrorToast.queueToast(localized("toast", path));
 		}
 
 		return result;

--- a/platforms/common/src/main/java/dynamic_fps/impl/feature/battery/ErrorToast.java
+++ b/platforms/common/src/main/java/dynamic_fps/impl/feature/battery/ErrorToast.java
@@ -1,0 +1,22 @@
+package dynamic_fps.impl.feature.battery;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.network.chat.Component;
+
+import static dynamic_fps.impl.util.Localization.localized;
+
+public class ErrorToast extends BaseToast {
+	private static final Component TITLE = localized("toast", "error");
+
+	private ErrorToast(Component description) {
+		super(TITLE, description, null);
+	}
+
+	/**
+	 * Queue some information to be shown as a toast.
+	 */
+	public static void queueToast(Component description) {
+		ErrorToast toast = new ErrorToast(description);
+		Minecraft.getInstance().getToastManager().addToast(toast);
+	}
+}

--- a/platforms/common/src/main/resources/assets/dynamic_fps/lang/en_us.json
+++ b/platforms/common/src/main/resources/assets/dynamic_fps/lang/en_us.json
@@ -86,6 +86,10 @@
     "gui.dynamic_fps.hud.reducing": "Dynamic FPS: Forcing Reduced FPS",
     "gui.dynamic_fps.hud.disabled": "Dynamic FPS Disabled",
 
+    "toast.dynamic_fps.error": "Dynamic FPS Battery Error",
+    "toast.dynamic_fps.no_support": "Computer is not supported",
+    "toast.dynamic_fps.no_library": "Library download disabled",
+
     "toast.dynamic_fps.battery_charging": "Charging!",
     "toast.dynamic_fps.battery_draining": "Discharging!",
     "toast.dynamic_fps.battery_critical": "Battery Low!",


### PR DESCRIPTION
Adds an error toast to give info on why the battery feature does not work. Shows up if either:
- the library can not be downloaded (disabled in config)
- the library does not support the system (shouldn't happen, but for completeness sake!)

Here's how it looks, with a normal battery toast as a comparison since I was making sure it works:
![](https://files.lostluma.net/3Q1Oer.png)