### PR TITLE
Fix rendering being blocked initially enabling the battery feature

### DIFF
--- a/platforms/common/src/main/java/dynamic_fps/impl/compat/GLFW.java
+++ b/platforms/common/src/main/java/dynamic_fps/impl/compat/GLFW.java
@@ -1,6 +1,7 @@
 package dynamic_fps.impl.compat;
 
 import dynamic_fps.impl.DynamicFPSMod;
+import dynamic_fps.impl.util.Threads;
 import dynamic_fps.impl.util.Version;
 import net.minecraft.client.Minecraft;
 
@@ -32,7 +33,7 @@ public class GLFW {
 			// Agrees that the window is focused. The mod is
 			// A little too fast for this, so we schedule it
 			// For the next client tick (before next frame).
-			minecraft.schedule(minecraft.mouseHandler::grabMouse);
+			Threads.runOnMainThread(minecraft.mouseHandler::grabMouse);
 		}
 	}
 

--- a/platforms/common/src/main/java/dynamic_fps/impl/util/Threads.java
+++ b/platforms/common/src/main/java/dynamic_fps/impl/util/Threads.java
@@ -1,0 +1,21 @@
+package dynamic_fps.impl.util;
+
+import net.minecraft.client.Minecraft;
+
+public class Threads {
+	/**
+	 * Schedule a task on the main thread.
+	 */
+	public static void runOnMainThread(Runnable runnable) {
+		Minecraft.getInstance().schedule(runnable);
+	}
+
+	/**
+	 * Create a thread and immediately start it.
+	 */
+	public static Thread create(String name, Runnable runnable) {
+		Thread thread = new Thread(runnable, "dynamic-fps-" + name);
+		thread.start();
+		return thread;
+	}
+}


### PR DESCRIPTION
Moves battery library initialization to a temporary thread.
Also adds `Threads` helper class so thread-related tasks only need to be changed in one place when porting.