### PR TITLE
Fix no FPS limit being applied when using a non-default idle condition

### DIFF
--- a/platforms/common/src/main/java/dynamic_fps/impl/Constants.java
+++ b/platforms/common/src/main/java/dynamic_fps/impl/Constants.java
@@ -13,6 +13,8 @@ public class Constants {
 	public static final int MIN_FRAME_RATE_LIMIT = 15;
 	// Minecraft considers limits >=260 as unlimited
 	public static final int NO_FRAME_RATE_LIMIT = 260;
+	// Default frame rate limit on all title screens
+	public static final int TITLE_FRAME_RATE_LIMIT = 60;
 
 	// The Cloth Config mod ID has changed a few times
 	public static final String[] CLOTH_CONFIG_ID = new String[] { "cloth-config", "cloth_config", "cloth-config2" };

--- a/platforms/common/src/main/java/dynamic_fps/impl/mixin/FramerateLimitTrackerMixin.java
+++ b/platforms/common/src/main/java/dynamic_fps/impl/mixin/FramerateLimitTrackerMixin.java
@@ -44,10 +44,12 @@ public class FramerateLimitTrackerMixin {
 			// Note: If Dynamic FPS thinks the user is idle the power state would be different above
 			if (condition != IdleCondition.VANILLA) {
 				// Since we're bypassing the idle checking code we also need to set the menu FPS here as it's bundled now
-				if (isInLevel() || !DynamicFPSConfig.INSTANCE.uncapMenuFrameRate()) {
+				if (isInLevel()) {
 					callbackInfo.setReturnValue(this.framerateLimit);
-				} else {
+				} else if(DynamicFPSConfig.INSTANCE.uncapMenuFrameRate()) {
 					callbackInfo.setReturnValue(this.getMenuFramerateLimit());
+				}else {
+					callbackInfo.setReturnValue(Constants.TITLE_FRAME_RATE_LIMIT);
 				}
 			}
 		}


### PR DESCRIPTION
Resolves #248.
Small bug that cropped up when converting the FPS limiting code to 1.21.2's new FramerateLimitTracker.