### PR TITLE
Fix loading overlay fade in showing a black screen

### DIFF
--- a/platforms/common/src/main/java/dynamic_fps/impl/DynamicFPSMod.java
+++ b/platforms/common/src/main/java/dynamic_fps/impl/DynamicFPSMod.java
@@ -250,7 +250,7 @@ public class DynamicFPSMod {
 
 	private static boolean isLevelCoveredByOverlay() {
 		Minecraft minecraft = Minecraft.getInstance();
-		return OVERLAY_OPTIMIZATION_ACTIVE && minecraft.getOverlay() instanceof LoadingOverlay && ((DuckLoadingOverlay)minecraft.getOverlay()).dynamic_fps$isReloadComplete();
+		return OVERLAY_OPTIMIZATION_ACTIVE && minecraft.getOverlay() instanceof LoadingOverlay && !((DuckLoadingOverlay)minecraft.getOverlay()).dynamic_fps$isReloadComplete();
 	}
 
 	@SuppressWarnings("squid:S1215") // Garbage collector call

--- a/platforms/common/src/main/java/dynamic_fps/impl/mixin/LoadingOverlayMixin.java
+++ b/platforms/common/src/main/java/dynamic_fps/impl/mixin/LoadingOverlayMixin.java
@@ -2,6 +2,8 @@ package dynamic_fps.impl.mixin;
 
 import net.minecraft.client.gui.screens.LoadingOverlay;
 
+import net.minecraft.server.packs.resources.ReloadInstance;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 
@@ -10,10 +12,11 @@ import dynamic_fps.impl.util.duck.DuckLoadingOverlay;
 @Mixin(LoadingOverlay.class)
 public class LoadingOverlayMixin implements DuckLoadingOverlay {
 	@Shadow
-	private long fadeOutStart;
+	@Final
+	private ReloadInstance reload;
 
 	@Override
 	public boolean dynamic_fps$isReloadComplete() {
-		return this.fadeOutStart > -1L;
+		return this.reload.isDone();
 	}
 }


### PR DESCRIPTION
Resolves #263.

Fixes the condition in `isLevelCoveredByOverlay` being inverted,  
as well as `dynamic_fps$isReloadComplete` returning that the reloading is done too late.
