### PR TITLE
Skip GPU utilization query while rendering 0 FPS

### DIFF
--- a/platforms/common/src/main/java/dynamic_fps/impl/mixin/bugfix/DebugScreenEntryListMixin.java
+++ b/platforms/common/src/main/java/dynamic_fps/impl/mixin/bugfix/DebugScreenEntryListMixin.java
@@ -1,0 +1,20 @@
+package dynamic_fps.impl.mixin.bugfix;
+
+import dynamic_fps.impl.DynamicFPSMod;
+import net.minecraft.client.gui.components.debug.DebugScreenEntries;
+import net.minecraft.client.gui.components.debug.DebugScreenEntryList;
+import net.minecraft.resources.Identifier;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(DebugScreenEntryList.class)
+public class DebugScreenEntryListMixin {
+	@Inject(method = "isCurrentlyEnabled", at = @At("HEAD"), cancellable = true)
+	private void isCurrentlyEnabled(Identifier identifier, CallbackInfoReturnable<Boolean> callbackInfo) {
+		if (DynamicFPSMod.targetFrameRate() == 0 && DebugScreenEntries.GPU_UTILIZATION.equals(identifier)) {
+			callbackInfo.setReturnValue(false);
+		}
+	}
+}

--- a/platforms/common/src/main/resources/dynamic_fps-common.mixins.json
+++ b/platforms/common/src/main/resources/dynamic_fps-common.mixins.json
@@ -12,7 +12,8 @@
         "OptionsMixin",
         "SoundEngineMixin",
         "ToastManagerMixin",
-        "bugfix.BlockableEventLoopMixin"
+        "bugfix.BlockableEventLoopMixin",
+        "bugfix.DebugScreenEntryListMixin"
     ],
     "mixins": [],
     "server": [],


### PR DESCRIPTION
Resolves #288.

This is only required for 1.21.9 through 1.21.11, in the 26.1 port I'm working on it'll be implicitly fixed.